### PR TITLE
Respect db_table name given in meta settings for TranslatedFields.

### DIFF
--- a/nani/models.py
+++ b/nani/models.py
@@ -33,7 +33,8 @@ def create_translations_model(model, related_name, meta, **fields):
     meta['unique_together'] = list(meta.get('unique_together', [])) + unique
     # Create inner Meta class 
     Meta = type('Meta', (object,), meta)
-    Meta.db_table = model._meta.db_table + '%stranslation' % getattr(settings, 'NANI_TABLE_NAME_SEPARATOR', '_')
+    if not hasattr(Meta, 'db_table'):
+        Meta.db_table = model._meta.db_table + '%stranslation' % getattr(settings, 'NANI_TABLE_NAME_SEPARATOR', '_')
     name = '%sTranslation' % model.__name__
     attrs = {}
     attrs.update(fields)

--- a/nani/tests/basic.py
+++ b/nani/tests/basic.py
@@ -291,3 +291,13 @@ class TableNameTest(NaniTestCase):
                     hello = models.CharField(max_length=128)
                 )
             self.assertEqual(MyOtherModel.translations.related.model._meta.db_table, 'tests_myothermodelO_Otranslation')
+
+    def test_table_name_from_meta(self):
+        from nani.models import TranslatedFields
+        from django.db import models
+        class MyNamedModel(TranslatableModel):
+            translations = TranslatedFields(
+                hello = models.CharField(max_length=128),
+                meta = {'db_table': 'tests_mymodel_i18n'},
+            )
+        self.assertEqual(MyNamedModel.translations.related.model._meta.db_table, 'tests_mymodel_i18n')


### PR DESCRIPTION
When creating the model for translated fields a table name given in the meta options of TranslatedFields should be respected.
