### PR TITLE
Test case showing problem with ManyToMany relations

### DIFF
--- a/nani/tests/__init__.py
+++ b/nani/tests/__init__.py
@@ -14,7 +14,7 @@ from nani.tests.query import (FilterTests, IterTests, UpdateTests,
     ValuesListTests, ValuesTests, DeleteTests, GetTranslationFromInstanceTests, 
     AggregateTests, NotImplementedTests, ExcludeTests, ComplexFilterTests)
 from nani.tests.related import (NormalToNormalFKTest, StandardToTransFKTest, 
-    TripleRelationTests)
+    TripleRelationTests, ManyToManyTest)
 from nani.tests.forms_inline import TestBasicInline
 from nani.tests.views import ViewsTest
 from nani.tests.limit_choices_to import LimitChoicesToTests

--- a/testproject/app/models.py
+++ b/testproject/app/models.py
@@ -29,6 +29,10 @@ class SimpleRelated(TranslatableModel):
     )
 
 
+class Many(models.Model):
+    name = models.CharField(max_length=128)
+    normals = models.ManyToManyField(Normal, related_name="manyrels")
+
 class Standard(models.Model):
     normal_field = models.CharField(max_length=255)
     normal = models.ForeignKey(Normal, related_name='standards')


### PR DESCRIPTION
I have been experiencing strange bugs where fetching translated objects across a many-to-many relation returns duplicate objects, or unrelated objects that should not be returned by the queryset. Here is a simple test case showing one example of a ManyToMany relation that gets ignored when fetching translated objects. 

The new test case fetches across a ManyToMany relation in two ways. The first way works fine, but the second way pulls in an unrelated object.

I think there is a problem with JOIN clauses in the SQL generated by django-hvad, but I'm not sure what's actually causing this. 
