### PR TITLE
Issue with forward-declared foreign keys

### DIFF
--- a/testproject/app/models.py
+++ b/testproject/app/models.py
@@ -79,3 +79,19 @@ class MultipleFields(TranslatableModel):
         first_translated_field = models.CharField(max_length=255),
         second_translated_field = models.CharField(max_length=255)
     )
+
+
+
+class ForwardRelated(TranslatableModel):
+    shared_field = models.CharField(max_length=255)
+    translations = TranslatedFields(
+        translated = models.ForeignKey("ReverseRelated", related_name='rel', null=True),
+    )
+
+
+class ReverseRelated(TranslatableModel):
+    shared_field = models.CharField(max_length=255)
+
+    translated_fields = TranslatedFields(
+        translated = models.CharField(max_length=1)
+    )


### PR DESCRIPTION
It seems that the check for multiple instances of TranslationModels also catches the case where there is a pre-existing foreign key from a TranslatableModel to the model being created.

I'm guessing that when the first (ForwardRelated) model is created, Django is creating a ReverseRelatedObjectsDescriptor to attach to the second (ReverseRelated) model. Then when the second model is actually created, the multiple translation model check is failing because of the reverse descriptor.

I didn't add an explicit unit test for this; just adding these two models into testproject/app/models.py is enough to stop the tests from being runnable.
