### PR TITLE
Adds current language code for django-cms plugin editor

### DIFF
--- a/hvad/templates/admin/hvad/change_form.html
+++ b/hvad/templates/admin/hvad/change_form.html
@@ -34,7 +34,7 @@
 <div class="nani-language-tabs">
 	{% for url,name,code,status in language_tabs %}
 	   {% if status == 'current' %}
-	       <span class="current">{{ name }}{% if current_is_translated and allow_deletion %}<a class="deletelink" href="./delete-translation/{{ code }}/" title="{% trans 'Delete Translation' %}">&nbsp;</a>{% endif %}</span>
+	       <span class="current" title="{{code}}">{{ name }}{% if current_is_translated and allow_deletion %}<a class="deletelink" href="./delete-translation/{{ code }}/" title="{% trans 'Delete Translation' %}">&nbsp;</a>{% endif %}</span>
        {% else %}
 	       <span class="{{ status }}"><a href="{{ url }}">{{ name }}</a> {% if status == 'available' and allow_deletion %}<a class="deletelink" href="./delete-translation/{{ code }}/" title="{% trans 'Delete Translation' %}">&nbsp;</a>{% endif %}</span>
        {% endif %} 


### PR DESCRIPTION
Hello, 
This issue has some history:
I made a  pull request 4 months ago, including a input tag for making django-cms be able to get current language: cf4be068f5

You stated that would be better to include a tittle into the span, as a better solution to having a hidden <input> element.

But this other solutions needs django-cms js plugin to  be changed.

Just now i have seen a pull request which does the same:
Related to #69

This patch adds the title field to current span, and I have a django-cms pull request ready to be sent, which will add suport to get language from current span title  (Also fixes another django-cms issue for language).

Maybe we should apply both solutions: the #69 for old django-cms instances to work, and this current span titlte for doing things well :). 
