### PR TITLE
made logging message more useful, less crashy

### DIFF
--- a/hvad/manager.py
+++ b/hvad/manager.py
@@ -569,7 +569,7 @@ class FallbackQueryset(QuerySet):
                 yield combine(translation, self.model)
             else:
                 # otherwise yield the shared instance only
-                logger.error("no translation for %s, type %s" % (instance, type(instance)))
+                logger.error("no translation for %s.%s (pk=%s)" % (instance._meta.app_label, instance.__class__.__name__, str(instance.pk)))
                 yield instance
         
     def iterator(self):


### PR DESCRIPTION
using the bare instance as an argument to the string formating, which
usually calls `__unicode__`, which in all likelihood tries to access a field
from the translated model, ending up with a

```
type object 'NoTranslation' has no attribute 'foobar'
```

error.
