### PR TITLE
django 1.6 compatibility - remove django.conf.urls.defaults

### DIFF
--- a/hvad/admin.py
+++ b/hvad/admin.py
@@ -127,7 +127,10 @@ class TranslatableAdmin(ModelAdmin, TranslatableModelAdminMixin):
     deletion_not_allowed_template = 'admin/hvad/deletion_not_allowed.html'
     
     def get_urls(self):
-        from django.conf.urls.defaults import patterns, url
+        try:
+            from django.conf.urls import patterns, url
+        except ImportError:
+            from django.conf.urls.defaults import patterns, url            
         
         urlpatterns = super(TranslatableAdmin, self).get_urls()
 


### PR DESCRIPTION
added exception handling for old django.conf.urls.defaults import behavior
