### PR TITLE
Add attribute translated_fields to TranslatableModelForm

### DIFF
--- a/hvad/forms.py
+++ b/hvad/forms.py
@@ -95,6 +95,12 @@ class TranslatableModelFormMetaclass(ModelFormMetaclass):
             fields = sfields
             fields.update(tfields)
             
+            # Add translated fields to the form to discern between translated
+            # and non-translated fields. This can be used to manipulate labels
+            # or other field attributes in __init__ of TranslatableModelForms. 
+            # For example: Prepend all translated fields with a globe icon
+            new_class.translated_fields = tfields
+            
             # make sure opts.fields doesn't specify an invalid field
             none_model_fields = [k for k, v in fields.items() if not v]
             missing_fields = set(none_model_fields) - \


### PR DESCRIPTION
Adding translated_fields to TranslatableModelForm allows properties of the translated fields to bet set dynamically, like prepending a globe icon, etc.

Example:

```
class WineForm(TranslatableModelForm):
    class Meta:
        model = Wine

    def __init__(self, *args, **kwargs):
        super(WineForm, self).__init__(*args, **kwargs)

        # Append globe icon to labels of translatable fields
        for field in self.translated_fields:
            self.fields[field].label += ' <span class="glyphicon glyphicon-globe"></span>'
```

This might then look something like this:
![screen shot 2013-10-30 at 01 07 24](https://f.cloud.github.com/assets/320033/1433543/556cbf3e-40f7-11e3-994e-e3f3f6a66c14.png)
