### PR TITLE
Remove object_id for self.pk_url_kwarg

### DIFF
--- a/hvad/views.py
+++ b/hvad/views.py
@@ -21,7 +21,7 @@ class TranslatableBaseView(UpdateView, TranslatableModelAdminMixin):
         """
         if "slug" in self.kwargs:
             return {self.slug_field: self.kwargs["slug"]}
-        return {'pk': self.kwargs['object_id']}
+        return {'pk': self.kwargs[self.pk_url_kwarg]}
 
     def get_form_class(self):
         language = self._language(self.request)


### PR DESCRIPTION
Not sure when exactly pk_url_kwarg was introduced, but this should definitely be changed, perhaps some backwards compatibility should be added if old django versions didn't support pk_url_kwarg
