### PR TITLE
Fix: Fieldtranslator fails on proxy model related fields

### DIFF
--- a/hvad/fieldtranslator.py
+++ b/hvad/fieldtranslator.py
@@ -41,13 +41,12 @@ def get_model_info(model):
     return MODEL_INFO[model]
 
 def _get_model_from_field(starting_model, fieldname):
-    # TODO: m2m handling
     field, model, direct, _ = starting_model._meta.get_field_by_name(fieldname)
-    if model:
-        return model
-    elif direct:
+    if direct and field.rel:        # field is on model, and is a relationship, follow it
         return field.rel.to
-    else:
+    elif direct and not field.rel:  # field is on model, and is not a relationship, stay there
+        return starting_model
+    else:                           # field it not on model, it is a related model pointing here, go there
         return field.model
 
 def translate(querykey, starting_model):

--- a/hvad/test_utils/project/app/models.py
+++ b/hvad/test_utils/project/app/models.py
@@ -50,6 +50,11 @@ class SimpleRelated(TranslatableModel):
     )
 
 
+class SimpleRelatedProxy(SimpleRelated):
+    class Meta:
+        proxy = True
+
+
 class Many(models.Model):
     name = models.CharField(max_length=128)
     normals = models.ManyToManyField(Normal, related_name="manyrels")


### PR DESCRIPTION
Querying a proxy model and using one of its ForeignKey (and friends) fields is currently broken.

``` python
class Normal(TranslatableModel):
    shared_field = models.CharField(max_length=255)
    translations = TranslatedFields(
        translated_field = models.CharField(max_length=255)
    )
class SimpleRelated(TranslatableModel):
    normal = models.ForeignKey(Normal, related_name='simplerel')
    translated_fields = TranslatedFields(
        translated_field = models.CharField(max_length=255),
    )
class SimpleRelatedProxy(SimpleRelated):
    class Meta:
        proxy = True

manager = get_translation_aware_manager(SimpleRelatedProxy)
manager.language('en').filter(normal__translated_field='English')
```

→ last line chokes as kwargs do not get translated, because fieldtranslator's __get_model_from_field_ is flawed:
If the tuple returned by get_field_by_name has a non-none model, it uses it.
Now, this item in the tuple has nothing to do with relationships and should not be used this way.

This only bites when using an inherited field for referencing another model, which is why it may have gone unnoticed. Attached fix includes a testcase for this specific issue.
