### PR TITLE
Fix: Removed all references to Model.objects, replaced by _default_manager

### DIFF
--- a/hvad/admin.py
+++ b/hvad/admin.py
@@ -311,7 +311,7 @@ class TranslatableAdmin(ModelAdmin, TranslatableModelAdminMixin):
         obj = super(TranslatableAdmin, self).get_object(request, object_id)
         if obj:
             return obj
-        queryset = self.model.objects.untranslated()
+        queryset = self.model._default_manager.untranslated()
         model = self.model
         try:
             object_id = model._meta.pk.to_python(object_id)

--- a/hvad/models.py
+++ b/hvad/models.py
@@ -105,7 +105,7 @@ class TranslatableModelBase(ModelBase):
             return super_new(cls, name, bases, attrs)
         new_model = super_new(cls, name, bases, attrs)
         opts = new_model._meta
-        if not opts.abstract and not isinstance(new_model.objects, TranslationManager):
+        if not opts.abstract and not isinstance(new_model._default_manager, TranslationManager):
             raise ImproperlyConfigured(
                 "The default manager on a TranslatableModel must be a "
                 "TranslationManager instance or an instance of a subclass of "

--- a/hvad/views.py
+++ b/hvad/views.py
@@ -43,7 +43,7 @@ class TranslatableBaseView(UpdateView, TranslatableModelAdminMixin):
             obj = None
         if obj:
             return obj
-        queryset = self.model.objects.untranslated()
+        queryset = self.model._default_manager.untranslated()
         try:
             obj = queryset.get(**self.filter_kwargs())
         except model.DoesNotExist:


### PR DESCRIPTION
In most places, hvad uses model._default_manager to reference the model's default manager, which is the right way to do it. I found a couple of places that have model.objects lingering around. This will change them for greater good.

I stumbled upon that while trying to switch objects to translationaware for one of my models:

``` python
unaware = TranslationManager()
objects = get_translation_aware_manager(Model)
```

That made the metaclass complain. Now it works!
