### PR TITLE
Fix #141: TranslatableModelAdmin uses absolute URLs for language tabs

### DIFF
--- a/hvad/admin.py
+++ b/hvad/admin.py
@@ -103,9 +103,7 @@ class TranslatableModelAdminMixin(object):
         language = self._language(request)
         for key, name in settings.LANGUAGES:
             get.update({'language': key})
-            url = '%s://%s%s?%s' % (request.is_secure() and 'https' or 'http',
-                                    request.get_host(), request.path,
-                                    urlencode(get))
+            url = '%s?%s' % (request.path, urlencode(get))
             if language == key:
                 status = 'current'
             elif key in available_languages:

--- a/hvad/tests/admin.py
+++ b/hvad/tests/admin.py
@@ -164,6 +164,24 @@ class NormalAdminTests(NaniTestCase, BaseAdminTests, SuperuserMixin):
                 response = self.client.get(url)
                 self.assertEqual(response.status_code, 200)
                 self.assertTrue('en' in response.content.decode('utf-8'))
+
+    def test_admin_change_form_language_tabs_urls(self):
+        with LanguageOverride('en'):
+            with self.login_user_context(username='admin', password='admin'):
+                obj = Normal.objects.language('en').create(
+                    shared_field="shared",
+                    translated_field='English',
+                )
+                get_url = reverse('admin:app_normal_change', args=(obj.pk,))
+                response = self.client.get(get_url)
+                self.assertEqual(response.status_code, 200)
+                tabs = response.context['language_tabs']
+
+                from hvad.compat.urls import urlencode
+                for actual_tab_url, name, key, status in tabs:
+                    expected_tab_url = '%s?%s' % (get_url,
+                        urlencode({'language': key}))
+                    self.assertEqual(expected_tab_url, actual_tab_url)
     
     def test_admin_change_form_redirect_add_another(self):
         lang = 'en'


### PR DESCRIPTION
Using absolute URLs is unnecessary and breaks access to the site through a reverse proxy.

On the language tabs of our admin, behind a reverse proxy, we see this:

```
<input type="hidden" class="language_button selected" name="en" />
<span class="current">English</span>
<span class="empty"><a href="http://fen-vz-inaspauthoraid.fen.aptivate.org/en/admin/news/newsitem/add/?language=es">Spanish</a> </span>
```

`fen-vz-inaspauthoraid.fen.aptivate.org` is an internal hostname which cannot be accessed without a VPN. It's not the URL that we used to load the page, through the reverse proxy.

It's not necessary to include a host and protocol in the rendered links. You can save a little bandwidth (page size) and avoid this problem by using relative links:

```
url = '%s?%s' % (request.path, urlencode(get))
```
