### PR TITLE
Django 1.6 renamed get_query_set functions to get_queryset.

### DIFF
--- a/docs/internal/manager.rst
+++ b/docs/internal/manager.rst
@@ -174,7 +174,7 @@ TranslationQueryset
         the initial class, the class from :attr:`override_classes` and
         :class:`TranslationQueryset`. Otherwise returns the class given.
     
-    .. method:: _get_shared_query_set(self)
+    .. method:: _get_shared_queryset(self)
     
         Returns a clone of this queryset but for the shared model. Does so by
         using :attr:`_real_manager` and filtering over this queryset. Returns a
@@ -257,7 +257,7 @@ TranslationQueryset
 
     .. method:: delete(self)
     
-        Deletes the :term:`Shared Model` using :meth:`_get_shared_query_set`.
+        Deletes the :term:`Shared Model` using :meth:`_get_shared_queryset`.
     
     .. method:: delete_translations(self)
     
@@ -271,7 +271,7 @@ TranslationQueryset
         two dictionaries holding only the shared or translated fields
         respectively. If translated fields are given, calls the superclass with
         the translated fields. If shared fields are given, uses
-        :meth:`_get_shared_query_set` to update the shared fields.
+        :meth:`_get_shared_queryset` to update the shared fields.
         
         If both shared and translated fields are updated, two queries are
         executed, if only one of the two are given, one query is executed.
@@ -356,14 +356,14 @@ TranslationManager
 
     .. method:: language(self, language_code=None)
     
-        Calls :meth:`get_query_set` to get a queryset and calls
+        Calls :meth:`get_queryset` to get a queryset and calls
         :meth:`TranslationQueryset.language` on that queryset.
     
     .. method:: untranslated(self)
     
         Returns an instance of :class:`FallbackQueryset` for this manager.
         
-    .. method:: get_query_set(self)
+    .. method:: get_queryset(self)
     
         Returns an instance of :class:`TranslationQueryset` for this manager.
         The queryset returned will have the *master* relation to the
@@ -433,9 +433,9 @@ TranslationFallbackManager
     .. method:: use_fallbacks(self, *fallbacks)
     
         Proxies to :meth:`FallbackQueryset.use_fallbacks` by calling
-        :meth:`get_query_set` first.
+        :meth:`get_queryset` first.
 
-    .. method:: get_query_set(self)
+    .. method:: get_queryset(self)
     
         Returns an instance of :class:`FallbackQueryset` for this manager.
 
@@ -599,6 +599,6 @@ TranslationAwareManager
 
 .. class:: TranslationAwareManager
 
-    .. method:: get_query_set(self)
+    .. method:: get_queryset(self)
 
         Returns an instance of :class:`TranslationAwareQueryset`.

--- a/hvad/manager.py
+++ b/hvad/manager.py
@@ -16,7 +16,6 @@ import logging
 import sys
 
 logger = logging.getLogger(__name__)
-DJANGO_VERSION = django.get_version()
 
 # maybe there should be an extra settings for this
 FALLBACK_LANGUAGES = [ code for code, name in settings.LANGUAGES ]
@@ -224,7 +223,7 @@ class TranslationQueryset(QuerySet):
                 return type(value.__name__, (value, klass, TranslationQueryset,), {})
         return klass
     
-    def _get_shared_query_set(self):
+    def _get_shared_queryset(self):
         qs = super(TranslationQueryset, self)._clone()
         qs.__class__ = QuerySet
         # un-select-related the 'master' relation
@@ -383,7 +382,7 @@ class TranslationQueryset(QuerySet):
         raise NotImplementedError()
 
     def delete(self):
-        qs = self._get_shared_query_set()
+        qs = self._get_shared_queryset()
         qs.delete()
     delete.alters_data = True
     
@@ -398,7 +397,7 @@ class TranslationQueryset(QuerySet):
         if translated:
             count += super(TranslationQueryset, self).update(**translated)
         if shared:
-            shared_qs = self._get_shared_query_set()
+            shared_qs = self._get_shared_queryset()
             count += shared_qs.update(**shared)
         return count
     update.alters_data = True
@@ -413,7 +412,7 @@ class TranslationQueryset(QuerySet):
 
     def dates(self, field_name, kind=None, order='ASC'):
         field_name = self.field_translator.get(field_name)
-        if int(django.get_version().split('.')[1][0]) <= 2:
+        if django.VERSION <= (1, 2):
             from hvad.compat.date import DateQuerySet
             return self._clone(klass=DateQuerySet, setup=True,
                 _field_name=field_name, _kind=kind, _order=order)
@@ -455,7 +454,7 @@ class TranslationQueryset(QuerySet):
 
                 # We need to force this to be a LEFT OUTER join, so we explicitly add the join.
                 # Django 1.6 changes the footprint of the Query.join method. See https://code.djangoproject.com/ticket/19385
-                if DJANGO_VERSION < '1.6':
+                if django.VERSION < (1, 6):
                     join_data = (field.model._meta.db_table, model._meta.db_table, bits[0] + "_id", 'id')
                 else:
                     join_data = (field, (field.model._meta.db_table, model._meta.db_table, ((bits[0] + "_id", 'id'),)))
@@ -475,7 +474,7 @@ class TranslationQueryset(QuerySet):
         obj = self._clone()
         obj.query.get_compiler(obj.db).fill_related_selections()  # seems to be necessary; not sure why
         for j in related_model_explicit_joins:
-            if DJANGO_VERSION >= '1.6':
+            if django.VERSION >= (1, 6):
                 kwargs = {'join_field': j[0]}
                 j = j[1]
             else:
@@ -619,7 +618,10 @@ class TranslationManager(models.Manager):
         return self.using_translations().language(language_code)
 
     def untranslated(self):
-        return self._fallback_manager.get_query_set()
+        if django.VERSION >= (1, 6):
+            return self._fallback_manager.get_queryset()
+        else:
+            return self._fallback_manager.get_query_set()
 
     #===========================================================================
     # Internals
@@ -632,7 +634,7 @@ class TranslationManager(models.Manager):
         """
         return self.model._meta.translations_model
 
-    #def get_query_set(self):
+    #def get_queryset(self):
     #    """
     #    Make sure that querysets inherit the methods on this manager (chaining)
     #    """
@@ -764,11 +766,15 @@ class TranslationFallbackManager(models.Manager):
     using `use_fallbacks()` to enable per object language fallback.
     """
     def use_fallbacks(self, *fallbacks):
-        return self.get_query_set().use_fallbacks(*fallbacks)
-    
-    def get_query_set(self):
+        if django.VERSION >= (1, 6):
+            return self.get_queryset().use_fallbacks(*fallbacks)
+        else:
+            return self.get_query_set().use_fallbacks(*fallbacks)
+
+    def get_queryset(self):
         qs = FallbackQueryset(self.model, using=self.db)
         return qs
+    get_query_set = get_queryset        # old name for Django < 1.6
 
 
 #===============================================================================
@@ -922,11 +928,15 @@ class TranslationAwareQueryset(QuerySet):
 
 class TranslationAwareManager(models.Manager):
     def language(self, language_code=None):
-        return self.get_query_set().language(language_code)
-        
-    def get_query_set(self):
+        if django.VERSION >= (1, 6):
+            return self.get_queryset().language(language_code)
+        else:
+            return self.get_query_set().language(language_code)
+
+    def get_queryset(self):
         qs = TranslationAwareQueryset(self.model, using=self.db)
         return qs
+    get_query_set = get_queryset        # old name for Django < 1.6
 
 
 #===============================================================================


### PR DESCRIPTION
After messing up my git history in #143, here is the same thing. Only, learning from my mistakes, I did not put it in master this time.

Quoting https://docs.djangoproject.com/en/dev/releases/1.6/ :

> **get_query_set and similar methods renamed to get_queryset**
> 
> Methods that return a QuerySet such as Manager.get_query_set or ModelAdmin.queryset have been renamed to get_queryset.

This leaves us with the _get_shared_query_set, which I renamed to _get_shared_queryset for consistency. This would break outside code using it. But it is an internal method and I cannot see why one would fiddle with it, so I guess it is safe.
