### PR TITLE
Link each all_translation entry to the corresponding admin page

### DIFF
--- a/docs/public/admin.rst
+++ b/docs/public/admin.rst
@@ -17,7 +17,8 @@ all_translations
 .. method:: all_translations(obj)
 
     A method that can be used in :attr:`list_display` and shows a list of
-    languages in which this object is available.
+    languages in which this object is available. Entries are linked to their
+    corresponding admin page.
 
 
 ***********************************************************

--- a/hvad/admin.py
+++ b/hvad/admin.py
@@ -1,8 +1,10 @@
 from distutils.version import LooseVersion
+import functools
 from django.conf import settings
 from django.contrib.admin.options import ModelAdmin, csrf_protect_m, InlineModelAdmin
 from django.contrib.admin.util import (flatten_fieldsets, unquote, 
     get_deleted_objects)
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.core.urlresolvers import reverse
 from django.db import router, transaction
@@ -81,11 +83,11 @@ class TranslatableModelAdminMixin(object):
             languages = []
             current_language = get_language()
             for language in obj.get_available_languages():
+                entry = '<a href="%s">%s</a>' % (self.get_url(obj, lang=language), language)
                 if language == current_language:
-                    languages.append(u'<strong>%s</strong>' % language)
-                else:
-                    languages.append(language)
-            return u' '.join(languages)
+                    entry = u'<strong>%s</strong>' % entry
+                languages.append(entry)
+            return u', '.join(languages)
         else:
             return ''
     all_translations.allow_tags = True
@@ -126,6 +128,20 @@ class TranslatableAdmin(ModelAdmin, TranslatableModelAdminMixin):
     
     deletion_not_allowed_template = 'admin/hvad/deletion_not_allowed.html'
     
+    def __init__(self, *args, **kwargs):
+        super(TranslatableAdmin, self).__init__(*args, **kwargs)
+        self.reverse = functools.partial(reverse, current_app=self.admin_site.name)
+
+
+    def get_url(self, obj, lang=None, get={}):
+        ct = ContentType.objects.get_for_model(self.model)
+        info = ct.app_label, ct.model
+        if lang:
+            get.update({self.query_language_key: lang})
+        url = '%s?%s' % (self.reverse('admin:%s_%s_change' % info, args=(obj.id,)), urlencode(get))
+        return url
+
+
     def get_urls(self):
         try:
             from django.conf.urls import patterns, url
@@ -200,7 +216,7 @@ class TranslatableAdmin(ModelAdmin, TranslatableModelAdminMixin):
         redirect = super(TranslatableAdmin, self).response_change(request, obj)
         uri = iri_to_uri(request.path)
         app_label, model_name = self.model._meta.app_label, self.model._meta.module_name
-        if redirect['Location'] in (uri, "../add/", reverse('admin:%s_%s_add' % (app_label, model_name))):
+        if redirect['Location'] in (uri, "../add/", self.reverse('admin:%s_%s_add' % (app_label, model_name))):
             if self.query_language_key in request.GET:
                 redirect['Location'] = '%s?%s=%s' % (redirect['Location'],
                     self.query_language_key, request.GET[self.query_language_key])
@@ -259,8 +275,8 @@ class TranslatableAdmin(ModelAdmin, TranslatableModelAdminMixin):
             )
 
             if not self.has_change_permission(request, None):
-                return HttpResponseRedirect(reverse('admin:index'))
-            return HttpResponseRedirect(reverse('admin:%s_%s_changelist' % (opts.app_label, opts.module_name)))
+                return HttpResponseRedirect(self.reverse('admin:index'))
+            return HttpResponseRedirect(self.reverse('admin:%s_%s_changelist' % (opts.app_label, opts.module_name)))
 
         object_name = '%s Translation' % force_unicode(opts.verbose_name)
 

--- a/hvad/tests/admin.py
+++ b/hvad/tests/admin.py
@@ -83,12 +83,14 @@ class NormalAdminTests(NaniTestCase, BaseAdminTests, SuperuserMixin):
             shared_field="shared",
         )
         with LanguageOverride('en'):
-            self.assertEqual(myadmin.all_translations(obj), "<strong>en</strong>")
-        
+            self.assertTrue(myadmin.all_translations(obj).find("<strong>") != -1)
+            # Entries should be linked to the corresponding translation page
+            self.assertTrue(myadmin.all_translations(obj).find("?language=en") != -1)
+
         with LanguageOverride('ja'):
-            self.assertEqual(myadmin.all_translations(obj), "en")
-            
-        # An unsaved object, shouldnt have any translations
+            self.assertTrue(myadmin.all_translations(obj).find("<strong>") == -1)
+
+        # An unsaved object, shouldn't have any translations
         
         obj = Normal()
         self.assertEqual(myadmin.all_translations(obj), "")


### PR DESCRIPTION
This makes a better user experience, and will speed up navigations.
Updates tests and documentation as well.
