### PR TITLE
Fix: if not queryset…

### DIFF
--- a/hvad/views.py
+++ b/hvad/views.py
@@ -34,7 +34,7 @@ class TranslatableBaseView(UpdateView, TranslatableModelAdminMixin):
                 return self.model._default_manager.language(language)
 
     def _get_object(self, queryset=None):
-        if not queryset:
+        if queryset is None:
             queryset = self.get_queryset()
         model = self.model
         try:


### PR DESCRIPTION
This is a one-liner, although it has performance and security implications.

Evaluating a queryset in a boolean context invokes its __nonzero__ method, which fetches all records and evaluates to False if no results are found. The actual intent there was to test whether the queryset argument was set, so let's just do that.

Also, if the queryset is empty, it will try to use get_queryset to make a new one out of the model, bypassing any filter that was applied to passed queryset, thus the security implications.

(I hit this mistake in my own code, then grep -r caught it in hvad too, so I figured I could share)
