### PR TITLE
Include documentation in source distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ include README.rst
 recursive-include nani/templates *
 recursive-include hvad/templates *
 recursive-include hvad/locale *
+recursive-include docs *
 prune testproject


### PR DESCRIPTION
It would be nice to include the documentation source in the releases too so people can build it for them-self using sphinx.
