### PR TITLE
Closes #130 - use translation accessor instead of direct query to access translations

### DIFF
--- a/hvad/models.py
+++ b/hvad/models.py
@@ -286,7 +286,7 @@ class TranslatableModel(with_metaclass(TranslatableModelBase, models.Model)):
             return stuff
 
         # get all translations
-        translations = self._meta.translations_model.objects.filter(master__pk=self.pk)
+        translations = getattr(self, self._meta.translations_accessor).all()
 
         # make them a nice dict
         translation_dict = {}


### PR DESCRIPTION
See #130 for issue and fix. As I had no news from the author, I cleaned up his PR.
It is very straightforward, though a good catch.
