### PR TITLE
Changed condition for insert inlines PK fields

### DIFF
--- a/hvad/templates/admin/hvad/edit_inline/stacked.html
+++ b/hvad/templates/admin/hvad/edit_inline/stacked.html
@@ -14,7 +14,7 @@
   {% for fieldset in inline_admin_form %}
     {% include "admin/includes/fieldset.html" %}
   {% endfor %}
-  {% if inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+  {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
   {{ inline_admin_form.fk_field.field }}
 </div>{% endfor %}
 </div>

--- a/hvad/templates/admin/hvad/edit_inline/tabular.html
+++ b/hvad/templates/admin/hvad/edit_inline/tabular.html
@@ -29,7 +29,7 @@
           {% if inline_admin_form.original %} {{ inline_admin_form.original }}{% endif %}
           {% if inline_admin_form.show_url %}<a href="../../../r/{{ inline_admin_form.original_content_type_id }}/{{ inline_admin_form.original.id }}/">{% trans "View on site" %}</a>{% endif %}
             </p>{% endif %}
-          {% if inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+          {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
           {{ inline_admin_form.fk_field.field }}
           {% spaceless %}
           {% for fieldset in inline_admin_form %}


### PR DESCRIPTION
I added TranslatableTabularInline class to my admin models and got `MultiValueDictKeyError` error when I was trying to save. I see that templates `/admin/hvad/edit_inline/` are old and update them by current version in Django's codebase (https://github.com/django/django/commit/3aad955ea8db1592fad0012155eaa25b72e50dc5). 
