### PR TITLE
Investigation needed: ModelAdmin's get_object

### DIFF
--- a/hvad/tests/admin.py
+++ b/hvad/tests/admin.py
@@ -111,22 +111,30 @@ class NormalAdminTests(NaniTestCase, BaseAdminTests, SuperuserMixin):
         
         obj = Normal.objects.language("en").create(
             shared_field="shared",
+            translated_field="translated_en",
         )
         with LanguageOverride('en'):
             self.assertEqual(myadmin.get_object(get_request, obj.pk).pk, obj.pk)
             self.assertEqual(myadmin.get_object(get_request, obj.pk).shared_field, obj.shared_field)
-            
+            self.assertEqual(myadmin.get_object(get_request, obj.pk).language_code, 'en')
+            self.assertEqual(myadmin.get_object(get_request, obj.pk).translated_field, obj.translated_field)
+
         with LanguageOverride('ja'):
             self.assertEqual(myadmin.get_object(get_request, obj.pk).pk, obj.pk)
             self.assertEqual(myadmin.get_object(get_request, obj.pk).shared_field, obj.shared_field)
-            
+            self.assertEqual(myadmin.get_object(get_request, obj.pk).language_code, 'ja')
+            self.assertEqual(myadmin.get_object(get_request, obj.pk).translated_field, '')
+
         # Check what happens if there is no translations at all
         obj = Normal.objects.untranslated().create(
             shared_field="shared",
         )
-        self.assertEqual(myadmin.get_object(get_request, obj.pk).pk, obj.pk)
-        self.assertEqual(myadmin.get_object(get_request, obj.pk).shared_field, obj.shared_field)
-        
+        with LanguageOverride('ja'):
+            self.assertEqual(myadmin.get_object(get_request, obj.pk).pk, obj.pk)
+            self.assertEqual(myadmin.get_object(get_request, obj.pk).shared_field, obj.shared_field)
+            self.assertEqual(myadmin.get_object(get_request, obj.pk).language_code, 'ja')
+            self.assertEqual(myadmin.get_object(get_request, obj.pk).translated_field, '')
+
             
     def test_get_object_nonexisting(self):
         # In case the object doesnt exist, it should return None


### PR DESCRIPTION
In #150, we talked about an issue with `ModelAdmin.get_object`.
It uses `self.get_queryset` to fetch the object. However, as `get_queryset` uses an `untranslated()` queryset, that automatically tries to load fallback translations, it is very likely it may, under some circumstances, load a wrong translation and overwrite it when submitting changes to an instance.

Fix 77669eed0543188cca302fec363304561e58786b was suggested, but it bypassed any overriden `get_queryset`, which would break the normal way of restricting editable instances.
- Further investigation on the exact circumstances in which this can happen would be needed.
- Even better, fixing the code so that `get_object` cannot load a wrong translation in the first place.
