### PR TITLE
Implement in_bulk method.

### DIFF
--- a/hvad/manager.py
+++ b/hvad/manager.py
@@ -381,7 +381,11 @@ class TranslationQueryset(QuerySet):
         return super(TranslationQueryset, self).latest(field_name)
 
     def in_bulk(self, id_list):
-        raise NotImplementedError()
+        if not id_list:
+            return {}
+        qs = self.filter(pk__in=id_list)
+        qs.query.clear_ordering(force_empty=True)
+        return dict([(obj._get_pk_val(), obj) for obj in qs.iterator()])
 
     def delete(self):
         qs = self._get_shared_queryset()
@@ -877,7 +881,11 @@ class TranslationAwareQueryset(QuerySet):
         return self._filter_extra(extra_filters).latest(field_name)
 
     def in_bulk(self, id_list):
-        raise NotImplementedError()
+        if not id_list:
+            return {}
+        qs = self.filter(pk__in=id_list)
+        qs.query.clear_ordering(force_empty=True)
+        return dict([(obj._get_pk_val(), obj) for obj in qs.iterator()])
 
     def values(self, *fields):
         fields, extra_filters = self._translate_fieldnames(fields)

--- a/hvad/tests/__init__.py
+++ b/hvad/tests/__init__.py
@@ -13,7 +13,7 @@ if django.VERSION < (1, 6): # Starting from django 1.6 we use DiscoverRunner ins
     from hvad.tests.forms import FormTests
     from hvad.tests.ordering import OrderingTest
     from hvad.tests.query import (FilterTests, IterTests, UpdateTests,
-        ValuesListTests, ValuesTests, DeleteTests, GetTranslationFromInstanceTests,
+        ValuesListTests, ValuesTests, InBulkTests, DeleteTests, GetTranslationFromInstanceTests,
         AggregateTests, NotImplementedTests, ExcludeTests, ComplexFilterTests)
     from hvad.tests.related import (NormalToNormalFKTest, StandardToTransFKTest,
         TripleRelationTests, ManyToManyTest, ForwardDeclaringForeignKeyTests,


### PR DESCRIPTION
Very straightforward (3 lines), basically the same as Django implementation except it uses `qs.filter` instead of `qs.query.add_filter` as the later would filter on **translations** ids, which is not what is intended.
Tests included.
