### PR TITLE
Fix #72: TranslationQueryset.language() should be lazy

### DIFF
--- a/docs/public/queryset.rst
+++ b/docs/public/queryset.rst
@@ -46,9 +46,12 @@ language
 
 .. method:: language(language_code=None)
     
-    Sets the language for the queryset to either the language code defined or
-    the currently active language. This method should be used for all queries
-    for which you want to have access to all fields on your model.
+    Sets the language for the queryset to either the given language code or
+    the currently active language if None. Language resolution will be deferred
+    until the query is evaluated.
+
+    This filters out all instances that are not translated in the given language,
+    and makes translatable fields available on the query results.
 
 
 .. _TranslationQueryset.untranslated-public:

--- a/hvad/test_utils/project/app/models.py
+++ b/hvad/test_utils/project/app/models.py
@@ -1,30 +1,39 @@
+import django
 from django.db import models
 from django.template.defaultfilters import slugify
 from hvad.models import TranslatableModel, TranslatedFields
+if django.VERSION >= (1, 4):
+    from django.utils.encoding import python_2_unicode_compatible
+else: # older versions do not run on py3, so we know we are running py2
+    def python_2_unicode_compatible(klass):
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+        return klass
 
-
+@python_2_unicode_compatible
 class Normal(TranslatableModel):
     shared_field = models.CharField(max_length=255)
     translations = TranslatedFields(
         translated_field = models.CharField(max_length=255)
     )
-    
-    def __unicode__(self):
+
+    def __str__(self):
         return self.safe_translation_getter('translated_field', self.shared_field)
 
-
+@python_2_unicode_compatible
 class NormalProxy(Normal):
 
-    def __unicode__(self):
+    def __str__(self):
         return u'proxied %s' % self.safe_translation_getter('translated_field', self.shared_field)
 
     class Meta:
         proxy = True
 
 
+@python_2_unicode_compatible
 class NormalProxyProxy(NormalProxy):
 
-    def __unicode__(self):
+    def __str__(self):
         return u'proxied^2 %s' % self.safe_translation_getter('translated_field', self.shared_field)
 
     class Meta:

--- a/hvad/tests/__init__.py
+++ b/hvad/tests/__init__.py
@@ -12,7 +12,7 @@ if django.VERSION < (1, 6): # Starting from django 1.6 we use DiscoverRunner ins
     from hvad.tests.fieldtranslator import FieldtranslatorTests
     from hvad.tests.forms import FormTests
     from hvad.tests.ordering import OrderingTest
-    from hvad.tests.query import (FilterTests, IterTests, UpdateTests,
+    from hvad.tests.query import (FilterTests, QueryCachingTests, IterTests, UpdateTests,
         ValuesListTests, ValuesTests, InBulkTests, DeleteTests, GetTranslationFromInstanceTests,
         AggregateTests, NotImplementedTests, ExcludeTests, ComplexFilterTests)
     from hvad.tests.related import (NormalToNormalFKTest, StandardToTransFKTest,

--- a/hvad/tests/admin.py
+++ b/hvad/tests/admin.py
@@ -334,10 +334,10 @@ class NormalAdminTests(NaniTestCase, BaseAdminTests, SuperuserMixin):
                 response = self.client.post(url, data_ja)
                 self.assertEqual(response.status_code, 302)
                 self.assertEqual(Normal.objects.count(), 2)
-            en = Normal.objects.using_translations().get(language_code='en')
+            en = Normal.objects.language('en').get()
             self.assertEqual(en.shared_field, SHARED)
             self.assertEqual(en.translated_field, TRANS_EN)
-            ja = Normal.objects.using_translations().get(language_code='ja')
+            ja = Normal.objects.language('ja').get()
             self.assertEqual(ja.shared_field, SHARED)
             self.assertEqual(ja.translated_field, TRANS_JA)
     

--- a/hvad/tests/basic.py
+++ b/hvad/tests/basic.py
@@ -216,7 +216,7 @@ class GetTest(NaniTestCase, OneSingleTranslatedNormalMixin):
     def test_get(self):
         en = Normal.objects.language('en').get(pk=1)
         with self.assertNumQueries(1):
-            got = Normal.objects.using_translations().get(pk=en.pk, language_code='en')
+            got = Normal.objects.language('en').get(pk=en.pk)
         with self.assertNumQueries(0):
             self.assertEqual(got.shared_field, "shared")
             self.assertEqual(got.translated_field, "English")

--- a/hvad/tests/dates.py
+++ b/hvad/tests/dates.py
@@ -20,6 +20,7 @@ class DatesTests(NaniTestCase, DatesMixin):
     def test_objects_dates(self):
         d2011 = datetime.date(year=2011, month=1, day=1)
         self.assertEqual(len(Date.objects.language('en').dates("shared_date", "year")), 2)
+        self.assertEqual(len(Date.objects.language('en').dates("shared_date", "year").all()), 2)
         self.assertEqual(len(Date.objects.language('en').dates("shared_date", "month")), 3)
         self.assertEqual(len(Date.objects.language('en').dates("shared_date", "day")), 3)
         self.assertEqual(len(Date.objects.language('en').dates("shared_date", "day").filter(shared_date__gt=d2011)), 2)


### PR DESCRIPTION
This makes `TranslationQueryset.language()` lazy.

Changes the call to `queryset.language()` so that it just stores None and defers actual filtering until query moment. This allows using `MyModel.objects.language()` in form definitions, and have the queryset call `get_language()` in the request/response context as mentionned in #72.
Also, as all other functions in the queryset family are lazy, I believe it is the right thing not to have `language()` stand out of the pack.

As a side effect, multiple calls to `language('xx')` now replace each other instead of returning an empty set.

**Note:** this change may break existing projects that would rely on invoking `language()` at a point, and keep the queryset around, expecting the same language later on.

Pull request includes a new _deferred_language_ test for all test cases in `hvad.tests.query`.
