### PR TITLE
Remove _real_manager and _fallback_manager indirections

### DIFF
--- a/docs/internal/manager.rst
+++ b/docs/internal/manager.rst
@@ -84,14 +84,6 @@ TranslationQueryset
     
         The cached field translator for this manager.
     
-    .. attribute:: _real_manager
-    
-        The real manager of the :term:`Shared Model`.
-        
-    .. attribute:: _fallback_manager
-    
-        The fallback manager of the :term:`Shared Model`.
-    
     .. attribute:: _language_code
     
         The language code of this queryset.
@@ -173,8 +165,8 @@ TranslationQueryset
     .. method:: _get_shared_queryset(self)
     
         Returns a clone of this queryset but for the shared model. Does so by
-        using :attr:`_real_manager` and filtering over this queryset. Returns a
-        queryset for the :term:`Shared Model`.
+        creating a :class:`django.db.query.QuerySet` on :attr:`shared_model`
+        and filtering over this queryset. Returns a queryset for the :term:`Shared Model`.
     
     .. method:: language(self, language_code=None)
     
@@ -323,7 +315,7 @@ TranslationQueryset
     .. method:: _clone(self, klass=None, setup=False, **kwargs)
     
         Injects *_local_field_names*, *_field_translator*, *_language_code*,
-        *_real_manager* and *_fallback_manager* into *kwargs*. If a *klass* is
+        and *shared_model* into *kwargs*. If a *klass* is
         given, calls :meth:`_get_class` to get a mixed class if necessary.
         
         Calls the superclass with the new *kwargs* and *klass*.
@@ -378,20 +370,7 @@ TranslationManager
     
     .. method:: contribute_to_class(self, model, name)
     
-        Contributes this manager, the real manager and the fallback manager onto
-        the class using :meth:`contribute_real_manager` and
-        :meth:`contribute_fallback_manager`.
-        
-    .. method:: contribute_real_manager(self)
-    
-        Creates a real manager and contributes it to the model after prefixing
-        the name with an underscore.
-    
-    .. method:: contribute_fallback_manager(self)
-    
-        Creates a fallback manager and contributes it to the model after
-        prefixing the name with an underscore and suffixing it with
-        ``'_fallback'``.
+        Contributes this manager onto the class.
 
 
 ****************

--- a/hvad/tests/query.py
+++ b/hvad/tests/query.py
@@ -219,18 +219,15 @@ class DeleteTests(NaniTestCase, TwoTranslatedNormalMixin):
     def test_delete_all(self):
         Normal.objects.all().delete()
         self.assertEqual(Normal.objects.count(), 0)
-        self.assertEqual(Normal.objects._real_manager.count(), 0)
         self.assertEqual(Normal._meta.translations_model.objects.count(), 0)
         
     def test_delete_translation(self):
         self.assertEqual(Normal._meta.translations_model.objects.count(), 4)
         Normal.objects.language('en').delete_translations()
         self.assertEqual(Normal.objects.untranslated().count(), 2)
-        self.assertEqual(Normal.objects._real_manager.count(), 2)
         self.assertEqual(Normal._meta.translations_model.objects.count(), 2)
         Normal.objects.language('ja').delete_translations()
         self.assertEqual(Normal.objects.untranslated().count(), 2)
-        self.assertEqual(Normal.objects._real_manager.count(), 2)
         self.assertEqual(Normal._meta.translations_model.objects.count(), 0)
 
 


### PR DESCRIPTION
Those serve no real purpose: they only ever get used for getting a vanilla queryset out of them, which can be done instanciating the queryset directly. This is what their `get_queryset` method does anyway, and the classes are hardcoded so it is not even useful to change their behavior.

Let's go direct, pass the `shared_model` along to the queryset instead of creating a fake manager, only to have a custom property return the manager's model in the end.

This interface is already fully tested, this patch changes no behavior of it, so no need to add new tests.
This is internal implementation details, but just in case, we should add to the release notes that:
- `MyModel.objects._real_manager` should be replaced with `QuerySet(MyModel)`.
- `MyModel.objects._fallback_manager` should be replaced with `MyModel.objects.untranslated()`. 

Not sure why anyone would have used one of the formers though.
