### PR TITLE
Support for django's datetimes queryset method

### DIFF
--- a/hvad/tests/dates.py
+++ b/hvad/tests/dates.py
@@ -1,3 +1,4 @@
+import django
 from hvad.test_utils.data import DATES_REVERSED, D3
 from hvad.test_utils.fixtures import DatesMixin
 from hvad.test_utils.testcase import NaniTestCase
@@ -22,3 +23,13 @@ class DatesTests(NaniTestCase, DatesMixin):
         self.assertEqual(len(Date.objects.language('en').dates("shared_date", "month")), 3)
         self.assertEqual(len(Date.objects.language('en').dates("shared_date", "day")), 3)
         self.assertEqual(len(Date.objects.language('en').dates("shared_date", "day").filter(shared_date__gt=d2011)), 2)
+
+class DatetimeTests(NaniTestCase, DatesMixin):
+    if django.VERSION >= (1, 6):
+        def test_object_datetimes(self):
+            d2011 = datetime.date(year=2011, month=1, day=1)
+            self.assertEqual(len(Date.objects.language('en').datetimes("shared_date", "year")), 2)
+            self.assertEqual(len(Date.objects.language('en').datetimes("shared_date", "month")), 3)
+            self.assertEqual(len(Date.objects.language('en').datetimes("shared_date", "day")), 3)
+            self.assertEqual(len(Date.objects.language('en').datetimes("shared_date", "day").filter(shared_date__gt=d2011)), 2)
+


### PR DESCRIPTION
Hello,

As of Django 1.6, django introduced a new method on the`Queryset` class called `datetimes` which does special filtering for`DateTimeField` objects.

You can read more about it [here](https://docs.djangoproject.com/en/1.6/releases/1.6/#time-zone-aware-aggregation).

The problem is that now, when referring to datetime fields on the master model, django will throw a`FieldDoesNotExist` error.

Currently hvad overrides most if not all`Queryset` methods to handle the field magic with both master and child models, so I believe this is all that's missing.
