### PR TITLE
Make get_available_languages use cached translations if they were prefetched.

### DIFF
--- a/docs/public/admin.rst
+++ b/docs/public/admin.rst
@@ -20,6 +20,10 @@ all_translations
     languages in which this object is available. Entries are linked to their
     corresponding admin page.
 
+    .. note:: You should add `prefetch_related('translations')` to your queryset
+              if you use this in :attr:`~django.contrib.admin.ModelAdmin.list_display`,
+              else one query will be run for every item in the list.
+
 
 ***********************************************************
 ModelAdmin APIs you should not change on TranslatableAdmin

--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -60,6 +60,12 @@ Fixes:
   queries allowed in Django 1.6 and newer to use only one query to resolve
   fallbacks. Old behavior can be forced by adding `HVAD_LEGACY_FALLBACKS = True`
   to your settings.
+- Method :meth:`~hvad.models.TranslatableModel.get_available_languages` will now
+  use prefetched translations if the instance was loaded from the database with
+  `prefetch_related('translations')`. Especially, using
+  :meth:`~hvad.admin.TranslatableAdmin.all_translations` in
+  :attr:`~django.contrib.admin.ModelAdmin.list_display` no longer results in one
+  query per item, as long as translations were prefetched.
 
 
 .. release 0.4.0

--- a/hvad/models.py
+++ b/hvad/models.py
@@ -325,8 +325,10 @@ class TranslatableModel(with_metaclass(TranslatableModelBase, models.Model)):
         return getattr(translation, name, default)
 
     def get_available_languages(self):
-        manager = self._meta.translations_model.objects
-        return manager.filter(master=self).values_list('language_code', flat=True)
+        qs = getattr(self, self._meta.translations_accessor).all()
+        if qs._result_cache is not None:
+            return [obj.language_code for obj in qs]
+        return qs.values_list('language_code', flat=True)
     
     #===========================================================================
     # Internals


### PR DESCRIPTION
Pretty much self explanatory. Fixes issue #97.
The method was always creating a query from scratch. Now it uses the translations accessor, which knows how to use prefetched objects.

``` python
obj = Model.objects.language().prefetch_related('translations').get(...)
obj.get_available_languages()    # now results in 0 query
```

This was causing a large number of queries when using `all_translations()` in `list_display`, in the admin.
