### PR TITLE
Implement support for abstract models

### DIFF
--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -32,6 +32,8 @@ New features:
 - All queryset classes used by :class:`~hvad.manager.TranslationManager` can now
   be customized thanks to the new :attr:`~hvad.manager.TranslationManager.fallback_class`
   and :attr:`~hvad.manager.TranslationManager.default_class` attributes.
+- Abstract models are now supported. The concrete class must still declare a
+  :class:`~hvad.models.TranslatedFields` instance, but it can be empty.
 
 Deprecation list:
 

--- a/hvad/test_utils/fixtures.py
+++ b/hvad/test_utils/fixtures.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.contrib.auth.models import User
-from hvad.test_utils.data import D1, D3, D2
-from hvad.test_utils.project.app.models import Normal, Date, Standard
+from hvad.test_utils.data import DOUBLE_NORMAL, D1, D3, D2
+from hvad.test_utils.project.app.models import Normal, Date, Standard, ConcreteAB
 
 
 class Fixture(object):
@@ -37,6 +37,40 @@ class TwoTranslatedNormalMixin(Fixture):
         ja2.save()
         super(TwoTranslatedNormalMixin, self).create_fixtures()
 
+
+class TwoTranslatedConcreteABMixin(TwoTranslatedNormalMixin):
+    def create_fixtures(self):
+        super(TwoTranslatedConcreteABMixin, self).create_fixtures()
+        normal1 = Normal.objects.language('en').get(shared_field='Shared1')
+        normal2 = Normal.objects.language('en').get(shared_field='Shared2')
+
+        ab1 = ConcreteAB.objects.language('en').create(
+            shared_field_a = DOUBLE_NORMAL[1]['shared_field'],
+            shared_field_b = normal1,
+            shared_field_ab = DOUBLE_NORMAL[1]['shared_field'],
+            translated_field_a = normal1,
+            translated_field_b = DOUBLE_NORMAL[1]['translated_field_en'],
+            translated_field_ab = DOUBLE_NORMAL[1]['translated_field_en'],
+        )
+        ab1.translate('ja')
+        ab1.translated_field_a = normal2
+        ab1.translated_field_b = DOUBLE_NORMAL[1]['translated_field_ja']
+        ab1.translated_field_ab = DOUBLE_NORMAL[1]['translated_field_ja']
+        ab1.save()
+
+        ab2 = ConcreteAB.objects.language('ja').create(
+            shared_field_a = DOUBLE_NORMAL[2]['shared_field'],
+            shared_field_b = normal2,
+            shared_field_ab = DOUBLE_NORMAL[2]['shared_field'],
+            translated_field_a = normal2,
+            translated_field_b = DOUBLE_NORMAL[2]['translated_field_ja'],
+            translated_field_ab = DOUBLE_NORMAL[2]['translated_field_ja'],
+        )
+        ab2.translate('en')
+        ab2.translated_field_a = normal1
+        ab2.translated_field_b = DOUBLE_NORMAL[2]['translated_field_en']
+        ab2.translated_field_ab = DOUBLE_NORMAL[2]['translated_field_en']
+        ab2.save()
 
 class SuperuserMixin(Fixture):
     def create_fixtures(self):

--- a/hvad/tests/__init__.py
+++ b/hvad/tests/__init__.py
@@ -26,3 +26,4 @@ if django.VERSION < (1, 6): # Starting from django 1.6 we use DiscoverRunner ins
     from hvad.tests.limit_choices_to import LimitChoicesToTests
     from hvad.tests.serialization import PicklingTest
     from hvad.tests.proxy import ProxyTests
+    from hvad.tests.abstract import AbstractTests

--- a/hvad/tests/abstract.py
+++ b/hvad/tests/abstract.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from hvad.test_utils.context_managers import LanguageOverride
+from hvad.test_utils.testcase import HvadTestCase
+from hvad.test_utils.project.app.models import (Normal, ConcreteAB, ConcreteABProxy)
+from hvad.test_utils.fixtures import TwoTranslatedConcreteABMixin
+from hvad.test_utils.data import DOUBLE_NORMAL
+
+class AbstractTests(HvadTestCase, TwoTranslatedConcreteABMixin):
+    def setUp(self):
+        super(AbstractTests, self).setUp()
+        self.normal1 = Normal.objects.language('en').get(shared_field=DOUBLE_NORMAL[1]['shared_field'])
+        self.normal2 = Normal.objects.language('en').get(shared_field=DOUBLE_NORMAL[2]['shared_field'])
+
+    def test_filter_and_iter(self):
+        with LanguageOverride('en'):
+            with self.assertNumQueries(1):
+                qs = (ConcreteAB.objects.language()
+                                        .filter(shared_field_a__startswith='Shared')
+                                        .order_by('shared_field_a'))
+                self.assertEqual(len(qs), 2)
+            with self.assertNumQueries(0):
+                self.assertEqual([obj.shared_field_b_id for obj in qs],
+                                 [self.normal1.pk, self.normal2.pk])
+                self.assertEqual([obj.shared_field_ab for obj in qs],
+                                 [DOUBLE_NORMAL[1]['shared_field'], DOUBLE_NORMAL[2]['shared_field']])
+                self.assertEqual([obj.translated_field_b for obj in qs],
+                                 [DOUBLE_NORMAL[1]['translated_field_en'],
+                                  DOUBLE_NORMAL[2]['translated_field_en']])
+                self.assertEqual([obj.translated_field_ab for obj in qs],
+                                 [DOUBLE_NORMAL[1]['translated_field_en'],
+                                  DOUBLE_NORMAL[2]['translated_field_en']])
+            with self.assertNumQueries(2): # this was not prefetched
+                self.assertEqual([obj.translated_field_a.pk for obj in qs],
+                                 [self.normal1.pk, self.normal1.pk])
+
+        qs = qs.all()   # discard cached results
+        with LanguageOverride('ja'):
+            with self.assertNumQueries(1):
+                self.assertEqual(len(qs), 2)
+            with self.assertNumQueries(0):
+                self.assertEqual([obj.translated_field_b for obj in qs],
+                                 [DOUBLE_NORMAL[1]['translated_field_ja'],
+                                  DOUBLE_NORMAL[2]['translated_field_ja']])
+                self.assertEqual([obj.translated_field_ab for obj in qs],
+                                 [DOUBLE_NORMAL[1]['translated_field_ja'],
+                                  DOUBLE_NORMAL[2]['translated_field_ja']])
+            with self.assertNumQueries(2): # this was not prefetched
+                self.assertEqual([obj.translated_field_a.pk for obj in qs],
+                                 [self.normal2.pk, self.normal2.pk])
+
+    def test_select_related(self):
+        with LanguageOverride('en'):
+            qs = (ConcreteAB.objects.language()
+                                    .select_related('shared_field_b', 'translated_field_a')
+                                    .filter(shared_field_ab=DOUBLE_NORMAL[2]['shared_field']))
+            # does it work?
+            with self.assertNumQueries(1):
+                self.assertEqual(qs.count(), 1)
+            with self.assertNumQueries(1):
+                self.assertEqual(len(qs), 1)
+                obj = qs[0]
+            # does it actually cache stuff?
+            with self.assertNumQueries(0):
+                self.assertEqual(obj.shared_field_b.translated_field, DOUBLE_NORMAL[2]['translated_field_en'])
+                self.assertEqual(obj.translated_field_a.translated_field, DOUBLE_NORMAL[1]['translated_field_en'])
+
+    def test_proxy(self):
+        obj = (ConcreteABProxy.objects.language('en')
+                                      .get(shared_field_a=DOUBLE_NORMAL[1]['shared_field']))
+        self.assertTrue(isinstance(obj, ConcreteABProxy))
+        self.assertTrue(str(obj).startswith('proxied'))


### PR DESCRIPTION
Self explanatory. See #44 as well.

**State before this PR:**
- abstract vanilla models can be inherited by translatable models.
- pretty much everything else breaks

**Objectives:**
- add support for translated fields on abstract models
- add support for combining translated fields from mutiple base abstract models
- provide consistent metadata about abstract models and _abstract model translations_
- maintain proxy model compatibility

The patch introduces _abstract model translations_. Those are abstract models automatically created by `create_translations_model` when given an abstract `TranslatableModel`. They hold the translatable fields, but no `language_code` and no `master` foreign key, as those would not make sense since the master is abstract.

The patch then builds the  _abstract model translations_ tree by reproducing the shared model inheritance tree (almost, models with no translated fields are skipped), and finally injects `language_code` and the `master` foreign key when it reaches a concrete model.

**Result:**
Example code is provided in [tests setup](https://github.com/KristianOellegaard/django-hvad/pull/180/files#diff-c0835c2b62d46f7470b82e953a956029R68).
This sets up a hierarchy of abstract translated models:

```
                              ┏━ AbstractAA ━ AbstractA ━ TranslatableModel
ConcreteABProxy ━ ConcreteAB ━┫
                              ┗━ AbstractB ━ TranslatableModel
```
