### PR TITLE
Add support for querying all languages at once with TranslationQueryset

### DIFF
--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -18,6 +18,8 @@ New features:
   :class:`~hvad.forms.BaseTranslationFormSet` allow building a formset to work
   on an instance's translations. Please have at look at its detailed
   :ref:`documentation <translationformset>`.
+- Method :meth:`~hvad.manager.TranslationQueryset.language` now accepts the
+  special value ``'all'``, allowing the query to consider all translations.
 - Django 1.6+'s new :meth:`~django.db.models.query.QuerySet.datetimes` method is
   now available on :class:`~hvad.manager.TranslationQueryset` too.
 - Django 1.6+'s new :meth:`~django.db.models.query.QuerySet.earliest` method is

--- a/hvad/tests/__init__.py
+++ b/hvad/tests/__init__.py
@@ -3,9 +3,12 @@ if django.VERSION < (1, 6): # Starting from django 1.6 we use DiscoverRunner ins
     from hvad.tests.admin import (NormalAdminTests, AdminEditTests,
         AdminNoFixturesTests, AdminDeleteTranslationsTests, AdminRelationTests,
         TranslatableInlineAdminTests)
-    from hvad.tests.basic import (OptionsTest, BasicQueryTest, AlternateCreateTest, CreateTest, GetTest,
-        TranslatedTest, DeleteLanguageCodeTest, GetByLanguageTest, DescriptorTests,
-        DefinitionTests, TableNameTest, GetOrCreateTest, BooleanTests)
+    from hvad.tests.basic import (OptionsTest, BasicQueryTest, AlternateCreateTest,
+                                  CreateTest, GetTest, TranslatedTest,
+                                  DeleteLanguageCodeTest, GetByLanguageTest,
+                                  GetAllLanguagesTest, DescriptorTests,
+                                  DefinitionTests, TableNameTest, GetOrCreateTest,
+                                  BooleanTests)
     from hvad.tests.dates import LatestTests, DatesTests
     from hvad.tests.docs import DocumentationTests
     from hvad.tests.fallbacks import (FallbackTests, FallbackFilterTests, FallbackCachingTests,

--- a/hvad/tests/basic.py
+++ b/hvad/tests/basic.py
@@ -263,6 +263,39 @@ class GetByLanguageTest(HvadTestCase, TwoTranslatedNormalMixin):
             self.assertEqual(obj.translated_field, DOUBLE_NORMAL[1]['translated_field_ja'])
 
 
+class GetAllLanguagesTest(HvadTestCase, TwoTranslatedNormalMixin):
+    def test_args(self):
+        with LanguageOverride('en'):
+            q = Q(pk=1)
+            with self.assertNumQueries(1):
+                objs = Normal.objects.language('all').filter(q)
+                self.assertEqual(len(objs), 2)
+                self.assertCountEqual((1, 1), (objs[0].pk, objs[1].pk))
+                self.assertCountEqual(('en', 'ja'), (objs[0].language_code, objs[1].language_code))
+
+    def test_kwargs(self):
+        with LanguageOverride('en'):
+            kwargs = {'pk':1}
+            with self.assertNumQueries(1):
+                objs = Normal.objects.language('all').filter(**kwargs)
+                self.assertEqual(len(objs), 2)
+                self.assertCountEqual((1, 1), (objs[0].pk, objs[1].pk))
+                self.assertCountEqual(('en', 'ja'), (objs[0].language_code, objs[1].language_code))
+
+    def test_translated_unique(self):
+        with LanguageOverride('en'):
+            with self.assertNumQueries(1):
+                obj = Normal.objects.language('all').get(translated_field=DOUBLE_NORMAL[1]['translated_field_ja'])
+                self.assertEqual(obj.pk, 1)
+                self.assertEqual(obj.language_code, 'ja')
+                self.assertEqual(obj.shared_field, DOUBLE_NORMAL[1]['shared_field'])
+                self.assertEqual(obj.translated_field, DOUBLE_NORMAL[1]['translated_field_ja'])
+
+    def test_get_all_raises(self):
+        with self.assertRaises(ValueError):
+            Normal.objects.language('en').get(pk=1, language_code='all')
+
+
 class BasicQueryTest(HvadTestCase, OneSingleTranslatedNormalMixin):
     def test_basic(self):
         en = Normal.objects.language('en').get(pk=1)


### PR DESCRIPTION
This PR adds support for passing `'all'` to `TranslationQueryset.language()`.
It has many uses, such as finding an object by translated field when the language the value is in is not known (for instance, when working with translatable slugs).

Especially, now that `language()` is lazily resolved, implementation is trivial. Most of the PR is testcases.
