### PR TITLE
"select_related" shouldn't raise NotImplementedError

### DIFF
--- a/docs/public/queryset.rst
+++ b/docs/public/queryset.rst
@@ -55,6 +55,8 @@ delete_translations
     Deletes all :term:`Translations Model` instances in a queryset, without
     deleting the :term:`Shared Model` instances.
 
+.. _select_related-public:
+
 select_related
 --------------
 
@@ -64,7 +66,8 @@ select_related
 
     The ``select_related`` method is limited to a one level depth when selecting
     related translatable models. Passing deeper relations to it will result in
-    an :exc:`~exceptions.NotImplementedError` being raised.
+    a warning being issued to logger `hvad.manager` and the relation being
+    truncated to first level.
 
 
 Not implemented public queryset methods

--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -70,6 +70,11 @@ Fixes:
   :meth:`~hvad.admin.TranslatableAdmin.all_translations` in
   :attr:`~django.contrib.admin.ModelAdmin.list_display` no longer results in one
   query per item, as long as translations were prefetched.
+- Using :ref:`select_related() <select_related-public>` with deep relations on a
+  :ref:`TranslationQueryset <TranslationQueryset-public>` no longers raises an
+  :exc:`~exceptions.NotImplementedError`. Rather, it logs a warning and truncates
+  the relation to the first level. This is more consistent with Django
+  behavior.
 
 
 .. release 0.4.0


### PR DESCRIPTION
Currently, calling `select_related` with more than one level raises a `NotImplementedError` (see https://github.com/KristianOellegaard/django-hvad/blob/master/hvad/manager.py#L439). This is inconsistent with Django's behaviour (which just ignores relations it cannot satisfy). Also. just ignoring instead of noisily complaining would allow me to already go and set up my queries for the case that django-hvad will support deeper relations one day. 
