### PR TITLE
delete_translations does not delete (some) translations

### DIFF
--- a/hvad/manager.py
+++ b/hvad/manager.py
@@ -469,8 +469,7 @@ class TranslationQueryset(QuerySet):
     
     def delete_translations(self):
         self.update(master=None)
-        qs = self._clone()._add_language_filter()
-        super(TranslationQueryset, qs).delete()
+        self.model.objects.filter(master__isnull=True).delete()
     delete_translations.alters_data = True
         
     def update(self, **kwargs):

--- a/hvad/tests/query.py
+++ b/hvad/tests/query.py
@@ -387,6 +387,19 @@ class DeleteTests(HvadTestCase, TwoTranslatedNormalMixin):
         self.assertEqual(Normal.objects.untranslated().count(), 2)
         self.assertEqual(Normal._meta.translations_model.objects.count(), 0)
 
+    def test_filtered_delete_translation(self):
+        self.assertEqual(Normal._meta.translations_model.objects.count(), 4)
+        (Normal.objects.language('en')
+                       .filter(shared_field=DOUBLE_NORMAL[1]['shared_field'])
+                       .delete_translations())
+        self.assertEqual(Normal.objects.untranslated().count(), 2)
+        self.assertEqual(Normal._meta.translations_model.objects.count(), 3)
+        (Normal.objects.language('ja')
+                       .filter(translated_field=DOUBLE_NORMAL[2]['translated_field_ja'])
+                       .delete_translations())
+        self.assertEqual(Normal.objects.untranslated().count(), 2)
+        self.assertEqual(Normal._meta.translations_model.objects.count(), 2)
+
     def test_delete_translation_deferred_language(self):
         self.assertEqual(Normal._meta.translations_model.objects.count(), 4)
         with LanguageOverride('ja'):


### PR DESCRIPTION
Simple example:

``` pycon
>>> qs = Normal.objects.language('en').filter(shared_field='Shared1')
>>> qs.delete_translations()
>>> QuerySet(model=qs.model, using=qs._db).filter(master__isnull=True).count()
1
```

**Result:** the targeted translation still lives. It is not obvious as it has its `master_id` set to `NULL` so it effectively disappears. But it stays around, and its unchained spirit might haunt some query results. Namely, issuing a query that uses no shared field and uses the same language will have it appear.

**Causes:** the method first `update()`s the translations to set their `master_id` to NULL. Therefore, the subsequent `delete()` will not find them when filtering on `master__shared_field`.

**Fix:**
- Possibility 1: well, I wonder what the point of setting `master_id` to NULL is. Why do we not simply DELETE th objects?
- Possibility 2: if there is really a good reason to update first, then we shoud just `QuerySet(model=self.model, using=self._db).filter(master__isnull=True).delete()`.
