### PR TITLE
Implement TranslationQueryset.fallbacks for Django 1.6+.

### DIFF
--- a/docs/internal/manager.rst
+++ b/docs/internal/manager.rst
@@ -108,6 +108,14 @@ TranslationQueryset
         - ``'all'``: no language filtering will be applied, a copy of an instance
           will be returned for every translation that matched the query.
 
+    .. attribute:: _language_fallbacks
+
+        A tuple of fallbacks used for this queryset, if fallbacks have been
+        activated by :meth:`fallbacks`, or `None` otherwise.
+
+        A ``None`` value in the tuple will be replaced with current language
+        at query evaluation.
+
     .. attribute:: translations_manager
     
         The (real) manager of the :term:`Translations Model`.
@@ -192,7 +200,7 @@ TranslationQueryset
 
         Apply the language filter to current query. Language is retrieved from
         :attr:`_language_code`, or :func:`~django.utils.translation.get_language` if
-        None.
+        None. If :meth:`fallbacks` have been set, apply the additional join as well.
 
         Special value ``'all'`` will prevent any language filter from being applied,
         resulting in the query considering all translations, possibly returning
@@ -234,6 +242,32 @@ TranslationQueryset
         .. note:: Using ``language('all')`` and :meth:`select_related` on the
                   same queryset is not supported and will raise a
                   :exc:`~exceptions.NotImplementedError`.
+
+    .. method:: fallbacks(self, *languages)
+
+        .. versionadded:: 0.6
+
+        Activates fallbacks for this queryset. This sets the
+        :attr:`_language_fallbacks` attribute, but does not apply any join
+        or filtering until :meth:`_add_language_filter` is called. This allows
+        for query-time resolution of the ``None`` values in the list.
+
+        The following special cases are accepted:
+
+        - ``None`` as a single argument will disable fallbacks on the queryset.
+        - An empty argument list will use :setting:`LANGUAGES` setting as a
+          fallback list.
+        - A ``None`` value a language will be replaced by the current language
+          at query evalution time, by calling
+          :func:`~django.utils.translation.get_language`
+
+        Returns a queryset.
+
+        .. note:: Using ``fallbacks`` and :meth:`select_related` on the
+                  same queryset is not supported and will raise a
+                  :exc:`~exceptions.NotImplementedError`.
+
+        .. note:: This feature requires Django 1.6 or newer.
 
     .. method:: create(self, **kwargs)
     

--- a/docs/public/queryset.rst
+++ b/docs/public/queryset.rst
@@ -49,6 +49,31 @@ language
     This filters out all instances that are not translated in the given language,
     and makes translatable fields available on the query results.
 
+fallbacks
+---------
+
+.. method:: fallbacks(*languages)
+
+    .. versionadded:: 0.6
+
+    Enables fallbacks on the queryset. When the queryset has fallbacks enabled,
+    it will try to use fallback languages if an object has not translation
+    available in the language given to :ref:`language() <language-public>`.
+
+    The `languages` arguments specified the languages to use, priorized from
+    first to last. Special value `None` will be replaced with current language
+    as returned by :func:`~django.utils.translation.get_language`. If called
+    with an empty argument list, the :setting:`LANGUAGES` setting will be used.
+
+    If an instance has no translation in the
+    :ref:`language() <language-public>`-specified language,
+    nor in any of the languages given to ``fallbacks()``, an arbitrary
+    translation will be picked.
+
+    Passing the single value ``None`` alone will disable fallbacks.
+
+    .. note:: This feature requires Django 1.6 or newer.
+
 delete_translations
 -------------------
 

--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -18,6 +18,13 @@ Python and Django versions supported:
 - Python 2.6 is no longer supported. Though it is likely to work for the time
   being, it has been dropped from the tested setups.
 
+New features:
+
+- :ref:`TranslationQueryset <TranslationQueryset-public>` now has a
+  :meth:`~hvad.manager.TranslationQueryset.fallbacks` method when running on
+  Django 1.6 or newer, allowing the queryset to use fallback languages while
+  retaining all its normal functionalities – :issue:`184`.
+
 
 .. release 0.5.0
 


### PR DESCRIPTION
Django 1.6 added a new `get_extra_restriction()` callback to fields, making it possible to inject custom predicates in JOIN clauses. This feature was leveraged in 45e397341d6dacfc1c19c7d342816ece335bac8b to cut down query number from `N/100` to `1` and fetched row count from `N*F` to `N` (with `F` the number of fallback languages).

This PR uses this further, by introducing a `fallbacks()` method on `TranslationQueryset` on Django 1.6 and newer. This allows getting fallbacks the same way `FallbackQueryset` does, while retaining all the features of `TranslationQueryset` yet not compromising on performance (actually improving it in fact).

The intent is to fully replace all the `FallbackQueryset` stuff, with its `untranslated()`-accessor-that-returns-a-queryset-that-actually-translates-objects-despite-its-name but, while translation-aware, cannot filter on translated fields.
Of course, as this requires Django 1.6 or newer, we will not actually remove `FallbackQueryset` anytime soon. Still, giving the option to do so to users of Django 1.6+ is good I think.

``` pycon
>>> Book.objects.language('fr').fallbacks('en').filter(category=novels)
[<Book: Le Petit Prince>, <Book: The Cuckoo's Egg>, <Book: Notre-Dame de Paris>]
>>> Book.objects.language('ja').fallbacks('en').filter(category=novels)
[<Book: 星の王子さま>, <Book: The Cuckoo's Egg>, <Book: The Hunchback of Notre-Dame>]
>>> Book.objects.language('ja').fallbacks('fr', 'en').filter(category=novels)
[<Book: 星の王子さま>, <Book: The Cuckoo's Egg>, <Book: Notre-Dame de Paris>]
```

**Allows the following forms:**
- `qs.fallbacks()`: use `settings.LANGUAGES` as fallback languages.
- `qs.fallbacks(None)`: disables fallbacks.
- `qs.fallbacks('en', 'ru', 'ja')`: sets the fallback list. Fallbacks priority is from first to last. `None` will be replaced with current language. Duplicate values are allowed (first wins).

Slight difference with `FallbackQueryset`: if an object has no translation available in one of the fallbacks languages, yet does have a translation available, an arbitrary translation will be picked. This is consistent with the behavior of `lazy_translation_getter`.
