### PR TITLE
Implement support for TranslatableModel.Meta.ordering option.

### DIFF
--- a/docs/public/models.rst
+++ b/docs/public/models.rst
@@ -36,10 +36,11 @@ A full example of a model with translations::
         )
 
 .. note:: The :djterm:`Meta <meta-options>` class of the model may not use the
-          translatable fields in its options. In particular, using them on
-          :attr:`~django.db.models.Options.ordering` or
-          :attr:`~django.db.models.Options.unique_together` will cause
-          inconsistent query results.
+          translatable fields in those options:
+
+          - :attr:`~django.db.models.Options.unique_together`
+          - :attr:`~django.db.models.Options.index_together`
+          - :attr:`~django.db.models.Options.order_with_respect_to`
 
 ***********************
 New and Changed Methods

--- a/docs/public/queryset.rst
+++ b/docs/public/queryset.rst
@@ -123,6 +123,11 @@ for each instance.
 .. warning:: You may not use any translated fields in any method on this
              queryset class.
 
+.. warning:: If you have a default :attr:`~django.db.models.Options.ordering`
+             defined on your model and it includes any translated field, you
+             must specify an ordering on every query so as not to use the
+             translated fields specified by the default ordering.
+
 New Methods
 ===========
 

--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -37,6 +37,9 @@ New features:
 - Abstract models are now supported. The concrete class must still declare a
   :class:`~hvad.models.TranslatedFields` instance, but it can be empty – :issue:`180`.
 - Django-hvad messages are now available in Italian – :issue:`178`.
+- The :attr:`Meta.ordering <django.db.models.Options.ordering>` model setting
+  is now supported on translatable models. It accepts both translated and shared
+  fields – :issue:`185`, :issue:`12`.
 
 Deprecation list:
 

--- a/hvad/manager.py
+++ b/hvad/manager.py
@@ -304,6 +304,13 @@ class TranslationQueryset(QuerySet):
                 f1 = {f: language_code}
                 f2 = {f: None}  # Allow select_related() to fetch objects with a relation set to NULL
                 self.query.add_q( Q(**f1) | Q(**f2) )
+
+        # if queryset is about to use the model's default ordering, we
+        # override that now with a translated version of the model's ordering
+        if self.query.default_ordering and not self.query.order_by:
+            ordering = self.shared_model._meta.ordering
+            self.query.order_by = self._translate_fieldnames(ordering or [])
+
         return self
 
     #===========================================================================

--- a/hvad/tests/__init__.py
+++ b/hvad/tests/__init__.py
@@ -17,7 +17,7 @@ if django.VERSION < (1, 6): # Starting from django 1.6 we use DiscoverRunner ins
                                       FallbackNotImplementedTests)
     from hvad.tests.fieldtranslator import FieldtranslatorTests
     from hvad.tests.forms import FormTests
-    from hvad.tests.ordering import OrderingTest
+    from hvad.tests.ordering import OrderingTest, DefaultOrderingTest
     from hvad.tests.query import (FilterTests, QueryCachingTests, IterTests, UpdateTests,
         ValuesListTests, ValuesTests, InBulkTests, DeleteTests, GetTranslationFromInstanceTests,
         AggregateTests, NotImplementedTests, ExcludeTests, ComplexFilterTests,

--- a/hvad/tests/ordering.py
+++ b/hvad/tests/ordering.py
@@ -1,45 +1,115 @@
 # -*- coding: utf-8 -*-
+import django
+from hvad.test_utils.data import DOUBLE_NORMAL
 from hvad.test_utils.testcase import HvadTestCase
 from hvad.test_utils.project.app.models import Normal
+from hvad.test_utils.fixtures import TwoTranslatedNormalMixin
+from hvad.exceptions import WrongManager
 
-class OrderingTest(HvadTestCase):
+class OrderingTest(HvadTestCase, TwoTranslatedNormalMixin):
+    def setUp(self):
+        super(OrderingTest, self).setUp()
+        self.a = Normal.objects.language('en').get(shared_field=DOUBLE_NORMAL[1]['shared_field'])
+        self.b = Normal.objects.language('en').get(shared_field=DOUBLE_NORMAL[2]['shared_field'])
+
     def test_minus_order_by(self):
-        a = Normal.objects.language('en').create(translated_field = "English",
-                                                 shared_field="A")
-        b = Normal.objects.language('en').create(translated_field = "English",
-                                                 shared_field="B")
         qs = Normal.objects.language('en').order_by('-shared_field')
-        self.assertEqual(qs.count(), 2)
-        self.assertEqual(qs[0].pk, b.pk)
-        self.assertEqual(qs[1].pk, a.pk)
-        
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.b.pk, self.a.pk))
+
+        qs = Normal.objects.language('en').order_by('-translated_field')
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.b.pk, self.a.pk))
+
     def test_order_by(self):
-        a = Normal.objects.language('en').create(translated_field = "English",
-                                                 shared_field="A")
-        b = Normal.objects.language('en').create(translated_field = "English",
-                                                 shared_field="B")
         qs = Normal.objects.language('en').order_by('shared_field')
-        self.assertEqual(qs.count(), 2)
-        self.assertEqual(qs[0].pk, a.pk)
-        self.assertEqual(qs[1].pk, b.pk)
-    
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.a.pk, self.b.pk))
+
+        qs = Normal.objects.language('en').order_by('translated_field')
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.a.pk, self.b.pk))
+
     def test_random_order(self):
-        a = Normal.objects.language('en').create(translated_field = "English",
-                                                 shared_field="A")
-        b = Normal.objects.language('en').create(translated_field = "English",
-                                                 shared_field="B")
         qs = Normal.objects.language('en').order_by('?')
         self.assertEqual(qs.count(), 2)
         pks = [obj.pk for obj in qs]
-        self.assertTrue(a.pk in pks)
-        self.assertTrue(b.pk in pks)
-        
+        self.assertTrue(self.a.pk in pks)
+        self.assertTrue(self.b.pk in pks)
+
     def test_reverse(self):
-        a = Normal.objects.language('en').create(translated_field = "English",
-                                                 shared_field="A")
-        b = Normal.objects.language('en').create(translated_field = "English",
-                                                 shared_field="B")
         qs = Normal.objects.language('en').order_by('shared_field').reverse()
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.b.pk, self.a.pk))
+
+        qs = Normal.objects.language('en').order_by('translated_field').reverse()
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.b.pk, self.a.pk))
+
+
+class DefaultOrderingTest(HvadTestCase, TwoTranslatedNormalMixin):
+    def setUp(self):
+        super(DefaultOrderingTest, self).setUp()
+        self.a = Normal.objects.language('en').get(shared_field=DOUBLE_NORMAL[1]['shared_field'])
+        self.b = Normal.objects.language('en').get(shared_field=DOUBLE_NORMAL[2]['shared_field'])
+
+    def test_minus_order_by_shared(self):
+        class ProxyWithOrder1(Normal):
+            class Meta:
+                proxy = True
+                ordering = ('-shared_field',)
+
+        qs = ProxyWithOrder1.objects.language('en')
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.b.pk, self.a.pk))
+
+        qs = ProxyWithOrder1.objects.untranslated()
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.b.pk, self.a.pk))
+
+    def test_order_by_shared(self):
+        class ProxyWithOrder2(Normal):
+            class Meta:
+                proxy = True
+                ordering = ('shared_field',)
+
+        qs = ProxyWithOrder2.objects.language('en')
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.a.pk, self.b.pk))
+
+        qs = ProxyWithOrder2.objects.untranslated()
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.a.pk, self.b.pk))
+
+    def test_minus_order_by_translated(self):
+        class ProxyWithOrder3(Normal):
+            class Meta:
+                proxy = True
+                ordering = ('-translated_field',)
+
+        qs = ProxyWithOrder3.objects.language('en')
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.b.pk, self.a.pk))
+
+        qs = ProxyWithOrder3.objects.untranslated()
+        self.assertRaises(WrongManager, len, qs)
+
+    def test_order_by_translated(self):
+        class ProxyWithOrder4(Normal):
+            class Meta:
+                proxy = True
+                ordering = ('translated_field',)
+
+        qs = ProxyWithOrder4.objects.language('en')
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.a.pk, self.b.pk))
+
+        qs = ProxyWithOrder4.objects.untranslated()
+        self.assertRaises(WrongManager, len, qs)
+
+    def test_ordered_fallback_no_raise(self):
+        class ProxyWithOrder5(Normal):
+            class Meta:
+                proxy = True
+                ordering = ('translated_field',)
+
+        qs = ProxyWithOrder5.objects.untranslated()
         self.assertEqual(qs.count(), 2)
-        self.assertEqual(qs[0].pk, b.pk)
-        self.assertEqual(qs[1].pk, a.pk)
+        self.assertEqual(qs.get(pk=1).pk, 1)
+        self.assertEqual(qs.in_bulk([1])[1].pk, 1)
+
+        qs = qs.order_by('-shared_field')
+        if django.VERSION >= (1, 6):
+            self.assertEqual(qs.first().pk, self.b.pk)
+            self.assertEqual(qs.last().pk, self.a.pk)
+        self.assertEqual(tuple(obj.pk for obj in qs), (self.b.pk, self.a.pk))
+        self.assertEqual(len(qs), 2)
+


### PR DESCRIPTION
**Objective:**
Add support for setting both translatable and untranslatable fields on the `ordering` option of translatable models. Before this PR, using this option requires ugly hacks (like ordering on `"master__shared_field"`).

**Method:**
Anticipate when the default model ordering will be used.
Force ordering to a translated version of default model ordering in that case.

**Result:**
Works as expected. Just one catch: if using translated fields on model's `ordering`, any use of a `FallbackQueryset` that uses the ordering must call `order_by`. This is logical as ordering on a translated field does not make sense on `untranslated()` queryset.
