### PR TITLE
Remove custom model metaclass

### DIFF
--- a/docs/internal/general.rst
+++ b/docs/internal/general.rst
@@ -11,9 +11,11 @@ How it works
 Model Definition
 ================
 
-The :class:`hvad.models.TranslatableModelBase` metaclass scans all attributes
-on the model defined for instances of :class:`hvad.models.TranslatedFields`, and
-if it finds one, sets the respective options onto meta.
+Function :func:`hvad.models.prepare_translatable_model` is invoked by Django
+metaclass using :data:`~django.db.models.signals.class_prepared` signal. It
+scans all attributes on the model defined for instances of
+:class:`hvad.models.TranslatedFields`, and if it finds one, sets the respective
+options onto meta.
 
 :class:`~hvad.models.TranslatedFields` both creates the
 :term:`Translations Model` and makes a foreign key from that model to point to

--- a/docs/internal/models.rst
+++ b/docs/internal/models.rst
@@ -15,6 +15,18 @@
     
     Returns the new model. 
 
+.. function:: contribute_translations(cls, rel)
+
+    Gets called from :func:`prepare_translatable_model` to set the
+    descriptors of the fields on the :term:`Translations Model` onto the
+    model.
+
+.. function:: prepare_translatable_model(sender)
+
+    Gets called from :class:`~django.db.models.Model`'s metaclass to
+    customize model creation. Performs checks, then contributes translations
+    and translation manager onto models that inherit
+    :class:`~hvad.models.TranslatableModel`.
 
 ****************
 TranslatedFields
@@ -51,7 +63,10 @@ TranslatableModelBase
 
 .. class:: TranslatableModelBase
 
-    Metaclass of :class:`TranslatableModel`.
+    .. deprecated:: 0.5
+
+    Metaclass of :class:`TranslatableModel`. It is no longer used and should be
+    removed from metaclass inheritance tree in projects.
 
     .. method:: __new__(cls, name, bases, attrs)
 
@@ -87,16 +102,10 @@ TranslatableModel
     
         A list of field on the :term:`Translations Model`.
     
-    .. classmethod:: contribute_translations(cls, rel)
-    
-        Gets called from the :class:`TranslatableModelBase` to set the
-        descriptors of the fields on the :term:`Translations Model` onto the
-        model.
-
     .. classmethod:: save_translations(cls, instance, **kwargs)
     
-        This classmethod is connected to the model's post save signal from the
-        :class:`TranslatableModelBase` and saves the cached translation if it's
+        This classmethod is connected to the model's post save signal from
+        :func:`prepare_translatable_model` and saves the cached translation if it's
         available.
     
     .. method:: translate(self, language_code)

--- a/docs/public/faq.rst
+++ b/docs/public/faq.rst
@@ -134,6 +134,12 @@ to force it to be in the user's preferred language by adding another query::
 How do I use hvad with MPTT?
 ****************************
 
+.. warning:: Since version 0.5, hvad no longer uses a custom metaclass, making this
+             solution unneeded. Although it will not break the way it is written
+             here, it becomes a verbose no-op and can be removed.
+
+             You might want to keep the manager subclassing at the end though.
+
 The `mptt`_ application implements Modified Preorder Tree Traversal
 for Django models. If you have any model in your project that is organized
 in a hierarchy of items, you should be using it.

--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -58,6 +58,9 @@ Deprecation list:
 - The :class:`~hvad.manager.TranslationFallbackManager` is deprecated and will
   be removed in next release. Please use manager's
   :meth:`~hvad.manager.TranslationManager.untranslated` method instead.
+- The :class:`~hvad.models.TranslatableModelBase` metaclass is no longer
+  necessary and will be removed in next release. hvad no longer triggers metaclass
+  conflicts and ``TranslatableModelBase`` can be safely dropped.
 
 Fixes:
 

--- a/hvad/tests/related.py
+++ b/hvad/tests/related.py
@@ -33,7 +33,12 @@ class NormalToNormalFKTest(HvadTestCase, OneSingleTranslatedNormalMixin):
         related.normal_id = 999
         related.save()
         self.assertRaises(Normal.DoesNotExist, getattr, related, 'normal')
-        
+
+    def test_reverse_relation(self):
+        normal = Normal.objects.language('en').get(pk=1)
+        related = Related.objects.language('en').create(normal=normal)
+
+        self.assertEqual(normal.rel1.language('en').get().pk, related.pk)
 
 
 class StandardToTransFKTest(HvadTestCase, TwoNormalOneStandardMixin):
@@ -220,10 +225,10 @@ class ManyToManyTest(HvadTestCase, TwoTranslatedNormalMixin):
             self.assertEqual([n.pk for n in normals], [normal1.pk])
             
             # Same thing, another way:
-            normals = many.normals.language() # This query is fetching Normal objects that are not associated with the Many object "many" !
+            normals = many.normals.language()
+            self.assertEqual([normal1.pk], [n.pk for n in normals])
             normals_plain = many.normals.all()
-            # The two queries above should return the same objects, since all normals are translated
-            self.assertEqual([n.pk for n in normals], [n.pk for n in normals_plain])
+            self.assertEqual([normal1.pk], [n.pk for n in normals_plain])
 
 
 class ForwardDeclaringForeignKeyTests(HvadTestCase):


### PR DESCRIPTION
This PR moves the code that customizes `TranslatableModel` subclasses from the `TranslatableModelBase` metaclass into a signal handler, connected to Django's builtin `class_prepared`. It gets triggered almost at the same point, but does not conflict with other metaclass-using apps.
We are 100% sure it gets registered in time as it is in the same module as `TranslatableModel`.

Here is the detailed list of changes:
- empty out `TranslatableModelBase` and mark it as deprecated. Testcase checks that nothing is broken and a warning is thrown.
- move its `__new__` method to a `prepare_translatable_model` signal handler.
- clean up the signal handler code: running a bit later, it needs less introspection to gather required data.
- force `_base_manager` to never be an instance of `TranslationManager` or a subclass. This was actually missing from the metaclass code (*)
- move the associated `contribute_translations` out of the model, next to the signal handler. It has no business inside the model class and polluted its namespace.

Tests pass. No behavior change was expected.

(*) it has no influence as `_base_manager` would only get overriden when using `use_for_related_fields = True`, and this override only breaks if the `default_class` of the queryset is set to `TranslationQueryset`. Still, this is the correct behavior.
