### PR TITLE
Clean up various style issues.

### DIFF
--- a/hvad/compat/query.py
+++ b/hvad/compat/query.py
@@ -1,0 +1,8 @@
+import django
+
+if django.VERSION >= (1, 7):
+    def get_where_node_field_name(node):
+        return node.lhs.target.name
+else:
+    def get_where_node_field_name(node):
+        return node[0].field.name

--- a/hvad/models.py
+++ b/hvad/models.py
@@ -13,6 +13,9 @@ from hvad.compat.settings import settings_updater
 import sys
 import warnings
 
+#===============================================================================
+
+# Global settings, wrapped so they react to SettingsOverride
 @settings_updater
 def update_settings(*args, **kwargs):
     global FALLBACK_LANGUAGES, TABLE_NAME_SEPARATOR
@@ -26,6 +29,7 @@ def update_settings(*args, **kwargs):
                       'be removed. Please rename it to HVAD_TABLE_NAME_SEPARATOR.',
                       DeprecationWarning)
 
+#===============================================================================
 
 def create_translations_model(model, related_name, meta, **fields):
     """
@@ -130,9 +134,6 @@ class BaseTranslationModel(models.Model):
     Needed for detection of translation models. Due to the way dynamic classes
     are created, we cannot put the 'language_code' field on here.
     """
-    def __init__(self, *args, **kwargs):
-        super(BaseTranslationModel, self).__init__(*args, **kwargs)
-        
     class Meta:
         abstract = True
 
@@ -266,6 +267,7 @@ class TranslatableModel(models.Model):
         return getattr(translation, name, default)
 
     def get_available_languages(self):
+        """ Get a list of all available language_code in db. """
         qs = getattr(self, self._meta.translations_accessor).all()
         if qs._result_cache is not None:
             return [obj.language_code for obj in qs]


### PR DESCRIPTION
Mostly focusing on manager.py.
- PEP8 style issues, though not all
- some comments on obscure code pieces
- some loops rewritten as list comprehensions
- more robust handling of `_unique` using a context manager
- hiding of `FieldTranslator` internals for better encapsulation (it no longer inherits `dict`, it has a `_cache` attribute instead).
- moving some method around so they are grouped by type (database query / queryset change / internals)
