### PR TITLE
Refactor select_related to support Django semantics and deep caching.

### DIFF
--- a/docs/internal/manager.rst
+++ b/docs/internal/manager.rst
@@ -204,6 +204,14 @@ TranslationQueryset
         field, as well as any related model translation set up by
         :meth:`select_related`.
 
+    .. method:: _add_select_related(self, language_code)
+
+        .. versionadded:: 0.5
+
+        Applies the related selections to current query. This includes the basic
+        selection of ``master``, any relation specified through :meth:`select_related`
+        and the translations of any translatable models it navigates through.
+
     .. method:: language(self, language_code=None)
     
         Specifies a language for this queryset. This sets the

--- a/docs/public/queryset.rst
+++ b/docs/public/queryset.rst
@@ -66,10 +66,11 @@ select_related
 
     Inherited from :meth:`~django.db.models.query.QuerySet.select_related`.
 
-    The ``select_related`` method is limited to a one level depth when selecting
-    related translatable models. Passing deeper relations to it will result in
-    a warning being issued to logger `hvad.manager` and the relation being
-    truncated to first level.
+    The ``select_related`` method also selects translations of translatable
+    models when it encounters some.
+
+    .. note:: ``select_related`` is not supported in combination with
+              ``language('all')``.
 
 
 Not implemented public queryset methods

--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -40,6 +40,12 @@ New features:
 - The :attr:`Meta.ordering <django.db.models.Options.ordering>` model setting
   is now supported on translatable models. It accepts both translated and shared
   fields – :issue:`185`, :issue:`12`.
+- The :meth:`~hvad.manager.TranslationQueryset.select_related` method is no longer
+  limited to 1 level depth.
+- The :meth:`~hvad.manager.TranslationQueryset.select_related` method semantics
+  is now consistent with that of regular querysets. It supports passing ``None``
+  to clear the list and mutiple calls mimic Django behavior. That is: cumulative
+  starting from Django 1.7 and substitutive before.
 
 Deprecation list:
 
@@ -71,12 +77,6 @@ Fixes:
   queries allowed in Django 1.6 and newer to use only one query to resolve
   fallbacks. Old behavior can be forced by adding ``HVAD_LEGACY_FALLBACKS = True``
   to your settings.
-- Using :ref:`select_related() <select_related-public>` with deep relations on a
-  :ref:`TranslationQueryset <TranslationQueryset-public>` no longers raises an
-  :exc:`~exceptions.NotImplementedError`. Rather, it logs a warning and truncates
-  the relation to the first level. This is more consistent with Django
-  behavior – :issue:`115`.
-
 
 .. release 0.4.1
 

--- a/hvad/test_utils/project/app/models.py
+++ b/hvad/test_utils/project/app/models.py
@@ -52,6 +52,7 @@ class RelatedProxy(Related):
     class Meta:
         proxy = True
 
+
 class SimpleRelated(TranslatableModel):
     normal = models.ForeignKey(Normal, related_name='simplerel')
     
@@ -63,6 +64,16 @@ class SimpleRelated(TranslatableModel):
 class SimpleRelatedProxy(SimpleRelated):
     class Meta:
         proxy = True
+
+
+class RelatedRelated(TranslatableModel):
+    related = models.ForeignKey(Related, related_name='+', null=True)
+    simple = models.ForeignKey(SimpleRelated, related_name='+', null=True)
+
+    translated_fields = TranslatedFields(
+        trans_related = models.ForeignKey(Related, related_name='+', null=True),
+        trans_simple = models.ForeignKey(SimpleRelated, related_name='+', null=True),
+    )
 
 
 class AbstractA(TranslatableModel):

--- a/hvad/tests/__init__.py
+++ b/hvad/tests/__init__.py
@@ -24,7 +24,7 @@ if django.VERSION < (1, 6): # Starting from django 1.6 we use DiscoverRunner ins
         MinimumVersionTests)
     from hvad.tests.related import (NormalToNormalFKTest, StandardToTransFKTest,
         TripleRelationTests, ManyToManyTest, ForwardDeclaringForeignKeyTests,
-        SelectRelatedTests)
+        SelectRelatedTests, DeepSelectRelatedTests)
     from hvad.tests.forms_inline import TestBasicInline, TestTranslationsInline
     from hvad.tests.views import ViewsTest
     from hvad.tests.limit_choices_to import LimitChoicesToTests


### PR DESCRIPTION
This is a full refactor of `select_related()` for TranslationQueryset.
From the outsite, it makes the following changes:
- support for arbitrarily deep `select_related()` clauses.
- accurate support of Django semantics, including v1.7+ breakup.
- lazy resolution of field references.

The internals have been redone, building on the `_add_language_filter` method added a few months ago. This patch ensures it is always called once and only once, allowing:
- removal of “safety methods” that were needlessly applying the filters just to be sure.
- loosening of constraints on `_add_language_filter` as it does not need to be idempotent anymore.

Tracking is done by tagging the queryset when language filters are applied. Tag is passed along in `_clone` and will make `_add_language_filter` raise and burn if called again.

Tests pass. New tests have been added for deep recursion caching. Documentation updates included.
Please note that accurate support of Django semantics might lower the performance of some projects that rely on current, broken behavior.
