### PR TITLE
Translatable ForeignKey cannot be assigned by id

### DIFF
--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -77,6 +77,8 @@ Fixes:
   queries allowed in Django 1.6 and newer to use only one query to resolve
   fallbacks. Old behavior can be forced by adding ``HVAD_LEGACY_FALLBACKS = True``
   to your settings.
+- Assigning value to translatable foreign keys through its ``_id`` field no
+  longer results in assigned value being ignored – :issue:`193`.
 
 .. release 0.4.1
 

--- a/hvad/descriptors.py
+++ b/hvad/descriptors.py
@@ -1,4 +1,5 @@
 import django
+from django.db.models.fields import FieldDoesNotExist
 from django.utils.translation import get_language
 from hvad.utils import get_translation
 if django.VERSION >= (1, 7):
@@ -43,8 +44,11 @@ class TranslatedAttribute(BaseDescriptor):
             if django.VERSION >= (1, 7) and not registry.apps.ready:
                 raise AttributeError('Attribute not available until registry is ready.')
             # Don't raise an attribute error so we can use it in admin.
-            return self.opts.translations_model._meta.get_field_by_name(
-                                                    self.name)[0].default
+            try:
+                return self.opts.translations_model._meta.get_field_by_name(
+                                                        self.name)[0].default
+            except FieldDoesNotExist as e:
+                raise AttributeError(e.message)
         return getattr(self.translation(instance), self.name)
     
     def __set__(self, instance, value):

--- a/hvad/models.py
+++ b/hvad/models.py
@@ -316,6 +316,9 @@ def contribute_translations(cls, rel):
             attr = LanguageCodeAttribute(opts)
         else:
             attr = TranslatedAttribute(opts, field.name)
+            attname = field.get_attname()
+            if attname and attname != field.name:
+                setattr(cls, attname, TranslatedAttribute(opts, attname))
         setattr(cls, field.name, attr)
 
 


### PR DESCRIPTION
Foreign keys in Django can normally be assigned by id, this way:

``` python
instance.related_id = related.pk
```

However, translatable models lack descriptors for the `*_id`. Therefore, if, in the above example, `related` is a translatable foreign key, the assignment will not be captured and end up setting an attribute on the shared model. As it is not in the right place, the ForeignKey field in turn will not save it.
