### PR TITLE
Implement full query translation (Q and F objects + deep kwargs)

### DIFF
--- a/hvad/query.py
+++ b/hvad/query.py
@@ -1,7 +1,182 @@
 import django
+from django.db import models
 from django.db.models import Q
 from django.db.models.expressions import ExpressionNode
+from django.db.models.sql.constants import QUERY_TERMS
 from django.db.models.sql.where import WhereNode
+
+
+class QueryTranslator(object):
+    ''' A stateful query translator, building up a list of language joins,
+        translated fields (for reverse translation) and additional related
+        queries.
+
+        Supports _clone() the same way Django querysets do, and update() to
+        merge in the tracked state from another translator.
+    '''
+    def __init__(self, model):
+        self.model = model
+        self._language_joins = set()
+        self._reverse_cache = {}
+        self._shared_fields = None
+        self.related_queries = {}
+
+    def update(self, other):
+        ''' Merge in the state of another QueryTranslator '''
+        assert self.model is other.model
+        self._language_joins.update(other._language_joins)
+        self._reverse_cache.update(other._reverse_cache)
+        self.related_queries.update(other.related_queries)
+
+    def _clone(self, klass=None):
+        if klass is None:
+            klass = self.__class__
+        c = klass(self.model)
+        c._language_joins = self._language_joins.copy()
+        c._reverse_cache = self._reverse_cache.copy()
+        c._shared_fields = self._shared_fields      # shared with parent
+        c.related_queries = self.related_queries.copy()
+        return c
+
+    @property
+    def shared_fields(self):
+        if self._shared_fields is None:
+            self._shared_fields = tuple(self.model._meta.get_all_field_names())
+        return self._shared_fields
+
+    def translate_query(self, path, nullable=False, related=False):
+        model = self.model
+        bits = path.split('__')
+        query_term = bits.pop() if bits[-1] in QUERY_TERMS else None
+
+        for depth, bit in enumerate(bits):
+            # STEP 1 -- Resolve the field
+            if bit == 'pk': # handle 'pk' alias
+                bit = model._meta.pk.name
+
+            if hasattr(model._meta, 'translations_accessor'):
+                # current model is a shared model
+                try:
+                    # is field on the shared model?
+                    field, _, direct, _ = model._meta.get_field_by_name.real(bit)
+                    translated = False
+                except models.FieldDoesNotExist:
+                    # nope, get field from translations model
+                    field, _, direct, _ = (model._meta.translations_model
+                                                ._meta.get_field_by_name(bit))
+                    translated = True
+            else:
+                # current model is a standard model
+                field, _, direct, _ = model._meta.get_field_by_name(bit)
+                translated = False
+
+            # STEP 2 -- Adjust the path bit to reflect real location of the field
+            if depth == 0 and not translated:
+                # current model is a translation, target is on shared model
+                bits[depth] = 'master__%s' % bit
+            elif depth > 0 and translated:
+                # current model is shared, target is on translation
+                taccessor = model._meta.translations_accessor
+                bits[depth] = '%s__%s' % (taccessor, bit)
+                self._language_joins.add(
+                    ('__'.join(bits[:depth] + [taccessor]), nullable)
+                )
+
+            # STEP 3 -- Find out the target of the relation, if it is one
+            if direct:  # field is on model
+                if field.rel:    # field is a foreign key, follow it
+                    target = field.rel.to
+                else:            # field is a regular field
+                    target = None
+            else:       # field is a m2m or reverse fk, follow it
+                target = field.model
+
+            # STEP 4 -- Some utility stuff
+            if related:
+                try:
+                    taccessor = target._meta.translations_accessor
+                except AttributeError:
+                    pass
+                else:
+                    query = '%s__%s' % ('__'.join(bits[:depth+1]), taccessor)
+                    self.related_queries[query] = getattr(target, taccessor).related.field
+                    self._language_joins.add((query, True))
+
+            # Raise a helpful exception if query bumps into non-relational fields
+            if target is None and depth != len(bits)-1:
+                raise ValueError('Found regular field %s in query %s' %
+                                ('__'.join(bits[:depth+1]), path))
+
+            # STEP 5 -- move on
+            model = target
+
+        result = '__'.join(bits)
+        if query_term is None:
+            self._reverse_cache[result] = path
+        else:
+            self._reverse_cache[result] = path[:-len(query_term)-2]
+            result = '%s__%s' % (result, query_term)
+        return result
+
+
+    def translate_kwarg(self, key, value):
+        if isinstance(value, ExpressionNode):
+            for node in expression_children(value):
+                if isinstance(node, F):
+                    node.name = self.translate_query(node.name)
+        return self.translate_query(key), value
+
+    def translate_args_kwargs(self, *args, **kwargs):
+        # Translate Q nodes in *args
+        for q in args:
+            for node, nodelist, index in q_children(q):
+                nodelist[index] = self.translate_kwarg(*node)
+        # Translate kwargs
+        newkwargs = dict(self.translate_kwarg(key, value) for key, value in kwargs.items())
+        return args, newkwargs
+
+    def translate_fieldnames(self, fieldnames, ordering=False):
+        if ordering:
+            result = []
+            for name in fieldnames:
+                if name == '?':
+                    result.append('?')
+                    continue
+                prefix, name = ('-', name[1:]) if name[0] == '-' else ('', name)
+                result.append('%s%s' % (prefix, self.translate_query(name)))
+            return tuple(result)
+        else:
+            return tuple(self.translate_query(key) for key in fieldnames)
+
+    def reverse_translate_fieldnames_dict(self, fieldname_dict):
+        """ Translates a translated path back to untranslated form
+            Can only translate paths issued from the same query
+        """
+        result = {}
+        for key, value in fieldname_dict.items():
+            try: # Most common case for ValuesQuerySet
+                result[self._reverse_cache[key]] = value
+                continue
+            except KeyError:
+                pass
+            try: # Automatically attributed aggregate aliases
+                root, tail = key.rsplit('__', 1)
+                result['%s__%s' % (self._reverse_cache[root], tail)] = value
+                continue
+            except (KeyError, ValueError):
+                pass
+            # Manually attributed aggregate aliases
+            result[key] = value
+        return result
+
+    def build_language_filters(self, language):
+        filters = []
+        for join, nullable in self._language_joins:
+            q_object = Q(**{'%s__language_code' % join: language})
+            if nullable:
+                q_object = q_object | Q(**{'%s__language_code' % join: None})
+            filters.append(q_object)
+        return filters
 
 #===============================================================================
 # Generators abstracting walking through internal django structures

--- a/hvad/test_utils/data.py
+++ b/hvad/test_utils/data.py
@@ -30,6 +30,15 @@ STANDARD = {
 
 #===============================================================================
 
+RelatedData = namedtuple('RelatedData', 'normal translated translated_to_translated')
+
+RELATED = {
+    1: RelatedData(1, {'en': 1, 'ja':2}, {'en': 2, 'ja': 1}),
+    2: RelatedData(2, {'en': 2, 'ja':2}, {'en': 1, 'ja': 1}),
+}
+
+#===============================================================================
+
 ConcreteABData = namedtuple('ConcreteABData',
                             'shared_field_a shared_field_b shared_field_ab '
                             'translated_field_a translated_field_b translated_field_ab')

--- a/hvad/test_utils/fixtures.py
+++ b/hvad/test_utils/fixtures.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from django.contrib.auth.models import User
-from hvad.test_utils.data import NORMAL, STANDARD, CONCRETEAB, DATE, QONORMAL
-from hvad.test_utils.project.app.models import Normal, Standard, ConcreteAB, Date, QONormal
+from hvad.test_utils.data import NORMAL, STANDARD, RELATED, CONCRETEAB, DATE, QONORMAL
+from hvad.test_utils.project.app.models import (Normal, Standard, Related, ConcreteAB,
+                                                Date, QONormal)
 
 
 class Fixture(object):
@@ -47,6 +48,27 @@ class StandardFixture(NormalFixture):
             normal_field=data.normal_field,
             normal_id=self.normal_id[data.normal],
         )
+        return obj
+
+
+class RelatedFixture(NormalFixture):
+    related_count = 0
+
+    def create_fixtures(self):
+        super(RelatedFixture, self).create_fixtures()
+        assert self.related_count <= len(RELATED)
+
+        self.related_id = {}
+        for i in range(1, self.related_count + 1):
+            self.related_id[i] = self.create_related(RELATED[i]).pk
+
+    def create_related(self, data, translations=None):
+        obj = Related(normal_id=self.normal_id[data.normal])
+        for code in translations or self.translations:
+            obj.translate(code)
+            obj.translated_id = self.normal_id[data.translated[code]]
+            obj.translated_to_translated_id = self.normal_id[data.translated_to_translated[code]]
+            obj.save()
         return obj
 
 

--- a/hvad/tests/related.py
+++ b/hvad/tests/related.py
@@ -335,16 +335,16 @@ class SelectRelatedTests(HvadTestCase, NormalFixture):
 
     def test_select_related_semantics(self):
         qs = Related.objects.language()
-        self.assertCountEqual(qs._raw_select_related, [])
+        self.assertCountEqual(qs._hvad_select_related, [])
         qs = qs.select_related('normal')
-        self.assertCountEqual(qs._raw_select_related, ['normal'])
+        self.assertCountEqual(qs._hvad_select_related, ['normal'])
         qs = qs.select_related('translated')
         if django.VERSION >= (1, 7):
-            self.assertCountEqual(qs._raw_select_related, ['normal', 'translated'])
+            self.assertCountEqual(qs._hvad_select_related, ['normal', 'translated'])
         else:
-            self.assertCountEqual(qs._raw_select_related, ['translated'])
+            self.assertCountEqual(qs._hvad_select_related, ['translated'])
         qs = qs.select_related(None)
-        self.assertCountEqual(qs._raw_select_related, [])
+        self.assertCountEqual(qs._hvad_select_related, [])
 
     def test_select_related(self):
         with LanguageOverride('en'):  


### PR DESCRIPTION
__WIP__
A couple of examples will go longer than complex explanations:
```python
# given Book (translatable), Author (not translatable) and Category (translatable)
qs = Book.objects.language('fr').filter(author__category__name='classique')
# or even better
qs = Book.objects.language('fr').select_related('author__category').filter(author__category__name='classique')

qs = Book.objects.language('fr').filter(Q(author__category__name='classique') | Q(author__category__date__year=1900))
```

That's the target. Full kwargs translation works, including Q and F objects. What needs to be done is adding the language constraints and, of course, testing. Don't get fooled by the tests passing, it just means it does not break stuff, not it works :)

Also, there are some code style issues. For instance, I wrote tree traversals as Visitor pattern, but it should be rewritten as iterator/generator, for both performance and "pythonicity".