### PR TITLE
admin: fix for TranslatableAdmin "prepopulated_fields"

### DIFF
--- a/hvad/admin.py
+++ b/hvad/admin.py
@@ -230,7 +230,7 @@ class TranslatableAdmin(ModelAdmin, TranslatableModelAdminMixin):
         current_is_translated = lang_code in available_languages
         context['current_is_translated'] = current_is_translated
         if not current_is_translated:
-            add = False
+            add = True
 
         context['allow_deletion'] = len(available_languages) > 1
         context['language_tabs'] = self.get_language_tabs(request, available_languages)


### PR DESCRIPTION
The problem is following:

django admin allows to use "prepopulated_fields_js" tag / feature only
if template context "add" variable is set to True. This is kind of
resonable - not to prepopulate eg. slug field that's already
saved). BUT. When you're editing translations for the given object only
first language has "add" context variable set to True in context. When
you switch tab to different language "add" is False (for already saved
object but different language).

Solution? - hvad.admin.TranslatableAdmin overrides original
"ModelAdmin.render_change_form" and adds some variables to context.
This includes "current_is_translated" which I use to override "add"
under the condition when translation for given language doesn't exists
yet.
