### PR TITLE
AttributeError: 'function' object has no attribute 'real'

### DIFF
--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -27,6 +27,8 @@ New features:
 
 Fixes:
 
+- Ecountering a regular (un-translatable) model in a deep `select_related` does
+  not break anymore. — :issue:`206`.
 - Language tabs URI are now correctly generated when changelist filters are used.
   — :issue:`203`.
 - Admin language tab selection is no longer lost when change filters are active.

--- a/hvad/manager.py
+++ b/hvad/manager.py
@@ -335,6 +335,9 @@ class TranslationQueryset(QuerySet):
                     field, _, direct, _ = (model._meta.translations_model
                                                 ._meta.get_field_by_name(bit))
                     translated = True
+                except AttributeError:           # model is not translatable anyway
+                    field, _, direct, _ = model._meta.get_field_by_name(bit)
+                    translated = False
 
                 # Adjust current path bit
                 if depth == 0 and not translated:

--- a/hvad/test_utils/project/app/models.py
+++ b/hvad/test_utils/project/app/models.py
@@ -98,6 +98,14 @@ class Standard(models.Model):
     normal = models.ForeignKey(Normal, related_name='standards')
 
 
+class StandardRelated(TranslatableModel):
+    """ Translatable mode with foreign key to untranslatable """
+    shared_field = models.CharField(max_length=255)
+    standard = models.ForeignKey(Standard, related_name='related')
+    translations = TranslatedFields(
+        translated_field = models.CharField(max_length=255),
+    )
+
 #===============================================================================
 # Models for testing abstract model support
 #


### PR DESCRIPTION
Hi,

I've the following models.

```
class UserProfile(models.Model):
    user = OneToOneField('auth.User')
    ...

class Review(TranslatableModel):
    translations = ...
    userprofile = models.ForeignKey(UserProfile)
    ...
```

When I try to query `Reviw.objects.language('en').all().select_related('userprofile__user')`, I get the error below:

```
Traceback (most recent call last):
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/django/core/handlers/base.py", line 114, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/rest_framework/viewsets.py", line 78, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/aykutozat/gezi/gezi/apps/api/v1/decorators.py", line 15, in inner_decorator
    return func(self, request, *args, **kwargs)
  File "/Users/aykutozat/gezi/gezi/apps/api/v1/mixins.py", line 82, in dispatch
    request, *args, **kwargs)
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 57, in wrapped_view
    return view_func(*args, **kwargs)
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/rest_framework/views.py", line 400, in dispatch
    response = self.handle_exception(exc)
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/rest_framework/views.py", line 397, in dispatch
    response = handler(request, *args, **kwargs)
  File "/Users/aykutozat/gezi/gezi/apps/api/v1/mixins.py", line 117, in reviews
    page = paginator.page(page_num)
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/django/core/paginator.py", line 50, in page
    number = self.validate_number(number)
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/django/core/paginator.py", line 39, in validate_number
    if number > self.num_pages:
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/django/core/paginator.py", line 86, in _get_num_pages
    if self.count == 0 and not self.allow_empty_first_page:
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/django/core/paginator.py", line 77, in _get_count
    self._count = len(self.object_list)
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/django/db/models/query.py", line 77, in __len__
    self._fetch_all()
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/django/db/models/query.py", line 854, in _fetch_all
    self._result_cache = list(self.iterator())
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/hvad/manager.py", line 464, in iterator
    qs = self._clone()._add_language_filter()
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/hvad/manager.py", line 405, in _add_language_filter
    self._add_select_related(language_code)
  File "/Users/aykutozat/.virtualenvs/gezi/lib/python2.7/site-packages/hvad/manager.py", line 318, in _add_select_related
    for query_key in fields:
AttributeError: 'function' object has no attribute 'real'
```

When I debug down to line 324 in `_add_select_related` method, I realize that model is `UserProfile` which is not a translatable model at `field, _, direct, _ = model._meta.get_field_by_name.real(bit)`.

Thank you.
Aykut
