### PR TITLE
Allow using TranslationQueryset as the default queryset: Model.objects.all()

### DIFF
--- a/docs/internal/manager.rst
+++ b/docs/internal/manager.rst
@@ -116,6 +116,14 @@ TranslationQueryset
         A ``None`` value in the tuple will be replaced with current language
         at query evaluation.
 
+    .. attribute:: _hvad_switch_fields
+
+        A tuple of attributes to move from the :term:`Translations Model` to the
+        :term:`Shared Model` instance before returning objects to the caller. It
+        is mostly used by :meth:`~django.db.models.query.QuerySet.extra` so
+        additional values collected by the ``select`` argument are available on
+        the final instance.
+
     .. attribute:: translations_manager
     
         The (real) manager of the :term:`Translations Model`.

--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -24,6 +24,10 @@ New features:
   :meth:`~hvad.manager.TranslationQueryset.fallbacks` method when running on
   Django 1.6 or newer, allowing the queryset to use fallback languages while
   retaining all its normal functionalities – :issue:`184`.
+- Passing additional ``select`` items in method
+  :meth:`~django.db.models.query.QuerySet.extra` is now supported. — :issue:`207`.
+- It is now possible to use :ref:`TranslationQueryset <TranslationQueryset-public>`
+  as default queryset for translatable models. — :issue:`207`.
 
 Fixes:
 

--- a/hvad/test_utils/data.py
+++ b/hvad/test_utils/data.py
@@ -17,6 +17,8 @@ NORMAL = {
     ),
 }
 
+QONORMAL = NORMAL
+
 #===============================================================================
 
 StandardData = namedtuple('StandardData', 'normal_field normal')

--- a/hvad/test_utils/fixtures.py
+++ b/hvad/test_utils/fixtures.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.contrib.auth.models import User
-from hvad.test_utils.data import NORMAL, STANDARD, CONCRETEAB, DATE
-from hvad.test_utils.project.app.models import Normal, Standard, ConcreteAB, Date
+from hvad.test_utils.data import NORMAL, STANDARD, CONCRETEAB, DATE, QONORMAL
+from hvad.test_utils.project.app.models import Normal, Standard, ConcreteAB, Date, QONormal
 
 
 class Fixture(object):
@@ -47,6 +47,26 @@ class StandardFixture(NormalFixture):
             normal_field=data.normal_field,
             normal_id=self.normal_id[data.normal],
         )
+        return obj
+
+
+class QONormalFixture(Fixture):
+    qonormal_count = 0
+
+    def create_fixtures(self):
+        super(QONormalFixture, self).create_fixtures()
+        assert self.qonormal_count <= len(QONORMAL), 'Not enough fixtures in data'
+
+        self.qonormal_id = {}
+        for i in range(1, self.qonormal_count + 1):
+            self.qonormal_id[i] = self.create_qonormal(QONORMAL[i]).pk
+
+    def create_qonormal(self, data, translations=None):
+        obj = QONormal(shared_field=data.shared_field)
+        for code in translations or self.translations:
+            obj.translate(code)
+            obj.translated_field = data.translated_field[code]
+            obj.save()
         return obj
 
 

--- a/hvad/test_utils/project/app/models.py
+++ b/hvad/test_utils/project/app/models.py
@@ -2,6 +2,7 @@ import django
 from django.db import models
 from django.template.defaultfilters import slugify
 from hvad.models import TranslatableModel, TranslatedFields
+from hvad.manager import TranslationManager, TranslationQueryset
 if django.VERSION >= (1, 4, 2):
     from django.utils.encoding import python_2_unicode_compatible
 else: # older versions do not run on py3, so we know we are running py2
@@ -105,6 +106,33 @@ class StandardRelated(TranslatableModel):
     translations = TranslatedFields(
         translated_field = models.CharField(max_length=255),
     )
+
+
+class FullTranslationManager(TranslationManager):
+    use_for_related_fields = True
+    default_class = TranslationQueryset
+
+class QONormal(TranslatableModel):
+    shared_field = models.CharField(max_length=255)
+    translations = TranslatedFields(
+        translated_field = models.CharField(max_length=255)
+    )
+    objects = FullTranslationManager()
+
+class QOSimpleRelated(TranslatableModel):
+    normal = models.ForeignKey(QONormal, related_name='simplerel', null=True)
+    translations = TranslatedFields(
+        translated_field = models.CharField(max_length=255),
+    )
+    objects = FullTranslationManager()
+
+class QOMany(TranslatableModel):
+    normals = models.ManyToManyField(QONormal, related_name="manyrels")
+    translations = TranslatedFields(
+        translated_field = models.CharField(max_length=255),
+    )
+    objects = FullTranslationManager()
+
 
 #===============================================================================
 # Models for testing abstract model support

--- a/hvad/tests/__init__.py
+++ b/hvad/tests/__init__.py
@@ -19,7 +19,7 @@ if django.VERSION < (1, 6): # Starting from django 1.6 we use DiscoverRunner ins
     from hvad.tests.fieldtranslator import FieldtranslatorTests
     from hvad.tests.forms import FormTests
     from hvad.tests.ordering import OrderingTest, DefaultOrderingTest
-    from hvad.tests.query import (FilterTests, QueryCachingTests, IterTests, UpdateTests,
+    from hvad.tests.query import (FilterTests, ExtraTests, QueryCachingTests, IterTests, UpdateTests,
         ValuesListTests, ValuesTests, InBulkTests, DeleteTests, GetTranslationFromInstanceTests,
         AggregateTests, NotImplementedTests, ExcludeTests, ComplexFilterTests,
         MinimumVersionTests)
@@ -32,3 +32,5 @@ if django.VERSION < (1, 6): # Starting from django 1.6 we use DiscoverRunner ins
     from hvad.tests.serialization import PicklingTest
     from hvad.tests.proxy import ProxyTests
     from hvad.tests.abstract import AbstractTests
+    from hvad.tests.queryset_override import (BasicTests, FilterTests, RelatedManagerTests,
+                                              PrefetchRelatedTests)

--- a/hvad/tests/admin.py
+++ b/hvad/tests/admin.py
@@ -372,11 +372,11 @@ class NormalAdminTests(HvadTestCase, BaseAdminTests, SuperuserFixture, NormalFix
             with LanguageOverride('en'):
                 response = self.client.post(url, data_en)
                 self.assertEqual(response.status_code, 302)
-                self.assertEqual(Normal.objects.count(), self.normal_count + 1)
+                self.assertEqual(Normal.objects.untranslated().count(), self.normal_count + 1)
             with LanguageOverride('ja'):
                 response = self.client.post(url, data_ja)
                 self.assertEqual(response.status_code, 302)
-                self.assertEqual(Normal.objects.count(), self.normal_count + 2)
+                self.assertEqual(Normal.objects.untranslated().count(), self.normal_count + 2)
             en = Normal.objects.language('en').get(shared_field=SHARED)
             self.assertEqual(en.shared_field, SHARED)
             self.assertEqual(en.translated_field, TRANS_EN)
@@ -399,7 +399,7 @@ class NormalAdminTests(HvadTestCase, BaseAdminTests, SuperuserFixture, NormalFix
                 }
                 response = self.client.post("%s?language=en" % url, data)
                 self.assertEqual(response.status_code, 302)
-                self.assertEqual(Normal.objects.count(), self.normal_count + 1)
+                self.assertEqual(Normal.objects.untranslated().count(), self.normal_count + 1)
                 obj = Normal.objects.language('en').get(shared_field=SHARED)
                 self.assertEqual(obj.shared_field, SHARED)
                 self.assertEqual(obj.translated_field, TRANS)

--- a/hvad/tests/query.py
+++ b/hvad/tests/query.py
@@ -86,6 +86,16 @@ class FilterTests(HvadTestCase, NormalFixture):
             self.assertEqual(obj2.shared_field, NORMAL[2].shared_field)
             self.assertEqual(obj2.translated_field, NORMAL[2].translated_field['en'])
 
+
+class ExtraTests(HvadTestCase, NormalFixture):
+    normal_count = 2
+
+    def test_simple_extra(self):
+        qs = Normal.objects.language('en').extra(select={'test_extra': '2 + 2'})
+        self.assertEqual(qs.count(), self.normal_count)
+        self.assertEqual(int(qs[0].test_extra), 4)
+
+
 class QueryCachingTests(HvadTestCase, NormalFixture):
     normal_count = 2
 

--- a/hvad/tests/queryset_override.py
+++ b/hvad/tests/queryset_override.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+import django
+from django.db.models.query_utils import Q
+from hvad.test_utils.context_managers import LanguageOverride
+from hvad.test_utils.data import QONORMAL
+from hvad.test_utils.testcase import HvadTestCase, minimumDjangoVersion
+from hvad.test_utils.project.app.models import QONormal, QOSimpleRelated, QOMany
+from hvad.test_utils.fixtures import NormalFixture, QONormalFixture
+from hvad.manager import TranslationManager, TranslationQueryset
+
+
+class BasicTests(HvadTestCase):
+    def test_queryset_class(self):
+        self.assertIsInstance(QONormal.objects.all(), TranslationQueryset)
+        self.assertIsInstance(QONormal.objects.language(), TranslationQueryset)
+        self.assertNotIsInstance(QONormal.objects.untranslated(), TranslationQueryset)
+        self.assertIs(QONormal._default_manager, QONormal.objects)
+
+        self.assertIsInstance(QOSimpleRelated.objects.all(), TranslationQueryset)
+        self.assertIsInstance(QOSimpleRelated.objects.language(), TranslationQueryset)
+        self.assertNotIsInstance(QOSimpleRelated.objects.untranslated(), TranslationQueryset)
+        self.assertIs(QOSimpleRelated._default_manager, QOSimpleRelated.objects)
+
+        self.assertIsInstance(QOMany.objects.all(), TranslationQueryset)
+        self.assertIsInstance(QOMany.objects.language(), TranslationQueryset)
+        self.assertNotIsInstance(QOMany.objects.untranslated(), TranslationQueryset)
+        self.assertIs(QOMany._default_manager, QOMany.objects)
+
+
+class FilterTests(HvadTestCase, QONormalFixture):
+    """ Basic filter tests - should work without issue as manager is just
+        as pass-through in those cases
+    """
+    qonormal_count = 2
+
+    def test_simple_filter(self):
+        with LanguageOverride('en'):
+            with self.assertNumQueries(2):
+                qs = QONormal.objects.filter(shared_field__contains='2')
+                self.assertEqual(qs.count(), 1)
+                obj = qs[0]
+            with self.assertNumQueries(0):
+                self.assertEqual(obj.shared_field, QONORMAL[2].shared_field)
+                self.assertEqual(obj.translated_field, QONORMAL[2].translated_field['en'])
+        with LanguageOverride('ja'):
+            with self.assertNumQueries(2):
+                qs = QONormal.objects.filter(shared_field__contains='1')
+                self.assertEqual(qs.count(), 1)
+                obj = qs[0]
+            with self.assertNumQueries(0):
+                self.assertEqual(obj.shared_field, QONORMAL[1].shared_field)
+                self.assertEqual(obj.translated_field, QONORMAL[1].translated_field['ja'])
+
+    def test_translated_filter(self):
+        with LanguageOverride('en'):
+            with self.assertNumQueries(2):
+                qs = QONormal.objects.filter(translated_field__contains='English').order_by('shared_field')
+                self.assertEqual(qs.count(), 2)
+                obj1, obj2 = qs
+            with self.assertNumQueries(0):
+                self.assertEqual(obj1.shared_field, QONORMAL[1].shared_field)
+                self.assertEqual(obj1.translated_field, QONORMAL[1].translated_field['en'])
+                self.assertEqual(obj2.shared_field, QONORMAL[2].shared_field)
+                self.assertEqual(obj2.translated_field, QONORMAL[2].translated_field['en'])
+
+    def test_deferred_language_filter(self):
+        with LanguageOverride('ja'):
+            qs = QONormal.objects.filter(translated_field__contains='English').order_by('shared_field')
+        with LanguageOverride('en'):
+            self.assertEqual(qs.count(), 2)
+            obj1, obj2 = qs
+        with LanguageOverride('ja'):
+            self.assertEqual(obj1.shared_field, QONORMAL[1].shared_field)
+            self.assertEqual(obj1.translated_field, QONORMAL[1].translated_field['en'])
+            self.assertEqual(obj2.shared_field, QONORMAL[2].shared_field)
+            self.assertEqual(obj2.translated_field, QONORMAL[2].translated_field['en'])
+
+
+class RelatedManagerTests(HvadTestCase, QONormalFixture):
+    qonormal_count = 2
+
+    def setUp(self):
+        super(RelatedManagerTests, self).setUp()
+        with LanguageOverride('en'):
+            self.normal1 = QONormal.objects.get(shared_field=QONORMAL[1].shared_field)
+            self.normal2 = QONormal.objects.get(shared_field=QONORMAL[2].shared_field)
+            self.related = QOSimpleRelated.objects.create(normal=self.normal1,
+                                                          translated_field='translated1_en')
+            # spurious instance to catch cases where filtering is not correct
+            obj = QOSimpleRelated.objects.create(normal=self.normal2,
+                                                 translated_field='dummy')
+            obj.translate('ja').save()
+
+            self.many1 = QOMany.objects.create(translated_field='translated1_en')
+            self.many1.translate('ja')
+            self.many1.translated_field = 'translated1_ja'
+            self.many1.save()
+            # spurious instance to catch cases where filtering is not correct
+            obj = QOMany.objects.create(translated_field='dummy')
+            obj.translate('ja').save()
+
+    def test_forward_foreign_key(self):
+        """ ForeignKey accessor should use the TranslationQueryset and fetch
+            the translation when it retrieves the shared model.
+        """
+        with LanguageOverride('en'):
+            related = QOSimpleRelated.objects.get(pk=self.related.pk)
+            self.assertEqual(related.translated_field, self.related.translated_field)
+
+            with self.assertNumQueries(1):
+                self.assertEqual(related.normal.shared_field, QONORMAL[1].shared_field)
+            with self.assertNumQueries(0):
+                self.assertEqual(related.normal.translated_field, QONORMAL[1].translated_field['en'])
+
+    def test_reverse_foreign_key_query(self):
+        """ Reverse foreign key should use the TranslationQueryset """
+        with LanguageOverride('en'):
+            qs = list(self.normal1.simplerel.all())
+            self.assertEqual(len(qs), 1)
+            with self.assertNumQueries(0):
+                self.assertEqual(qs[0].normal_id, self.qonormal_id[1])
+                self.assertEqual(qs[0].translated_field, self.related.translated_field)
+
+        with LanguageOverride('ja'):
+            qs = list(self.normal1.simplerel.all())
+            self.assertEqual(len(qs), 0)
+
+    def test_reverse_foreign_key_updates(self):
+        """ Reverse foreign key should use the TranslationQueryset for adding/removing """
+        with LanguageOverride('en'):
+            self.assertEqual(self.normal1.simplerel.count(), 1)
+            self.normal1.simplerel.clear()
+            self.assertEqual(self.normal1.simplerel.count(), 0)
+            self.normal1.simplerel.add(self.related)
+            self.assertEqual(self.normal1.simplerel.count(), 1)
+            self.normal1.simplerel.remove(self.related)
+            self.assertEqual(self.normal1.simplerel.count(), 0)
+
+            self.normal1.simplerel.create(translated_field='test_en')
+            self.assertEqual(self.normal1.simplerel.language('en').count(), 1)
+            self.assertEqual(self.normal1.simplerel.language('ja').count(), 0)
+            obj = self.normal1.simplerel.get(translated_field='test_en')
+            self.assertEqual(obj.normal_id, self.normal1.pk)
+
+    def test_forward_many_to_many_query(self):
+        """ Forward side of many to many relation should use the TranslationQueryset
+        """
+        with LanguageOverride('en'):
+            many = QOMany.objects.get(translated_field='translated1_en')
+
+            qs = many.normals.all()
+            self.assertEqual(len(qs), 0)
+
+            many.normals.add(self.normal1)
+            qs = list(many.normals.all())
+            with self.assertNumQueries(0):
+                self.assertEqual(len(qs), 1)
+                self.assertEqual(qs[0].shared_field, QONORMAL[1].shared_field)
+                self.assertEqual(qs[0].translated_field, QONORMAL[1].translated_field['en'])
+
+            qs = list(many.normals.filter(translated_field=QONORMAL[1].translated_field['en']))
+            with self.assertNumQueries(0):
+                self.assertEqual(len(qs), 1)
+                self.assertEqual(qs[0].shared_field, QONORMAL[1].shared_field)
+                self.assertEqual(qs[0].translated_field, QONORMAL[1].translated_field['en'])
+
+    def test_forward_many_to_many_updates(self):
+        with LanguageOverride('en'):
+            many = QOMany.objects.get(translated_field='translated1_en')
+
+            many.normals.add(self.normal1, self.normal2)
+            self.assertEqual(many.normals.count(), 2)
+            many.normals.remove(self.normal2)
+            self.assertEqual(many.normals.count(), 1)
+            self.assertEqual(many.normals.get().pk, self.qonormal_id[1])
+            obj = many.normals.create(translated_field='test_en')
+            self.assertEqual(many.normals.count(), 2)
+            self.assertEqual(many.normals.language('ja').count(), 1)
+            self.assertEqual(list(obj.manyrels.values_list('pk', flat=True)), [many.pk])
+            many.normals.clear()
+            self.assertEqual(many.normals.count(), 0)
+
+    def test_reverse_many_to_many_query(self):
+        """ Reverse side of many to many relation should use the TranslationQueryset
+        """
+        with LanguageOverride('en'):
+            many = QOMany.objects.get(translated_field='translated1_en')
+            many.normals.add(self.normal1)
+
+            normal = QONormal.objects.get(pk=self.normal1.pk)
+            qs = list(normal.manyrels.all())
+            with self.assertNumQueries(0):
+                self.assertEqual(len(qs), 1)
+                self.assertEqual(qs[0].translated_field, 'translated1_en')
+
+            qs = list(normal.manyrels.filter(translated_field='translated1_en'))
+            with self.assertNumQueries(0):
+                self.assertEqual(len(qs), 1)
+                self.assertEqual(qs[0].translated_field, 'translated1_en')
+
+
+@minimumDjangoVersion(1, 4)
+class PrefetchRelatedTests(HvadTestCase, QONormalFixture):
+    qonormal_count = 2
+
+    def setUp(self):
+        super(PrefetchRelatedTests, self).setUp()
+        with LanguageOverride('en'):
+            self.normal1 = QONormal.objects.get(shared_field=QONORMAL[1].shared_field)
+            self.normal2 = QONormal.objects.get(shared_field=QONORMAL[2].shared_field)
+            self.related = QOSimpleRelated.objects.create(normal=self.normal1,
+                                                          translated_field='translated1_en')
+            # spurious instance to catch cases where filtering is not correct
+            obj = QOSimpleRelated.objects.create(normal=self.normal2,
+                                                 translated_field='dummy')
+            obj.translate('ja').save()
+
+            self.many1 = QOMany.objects.create(translated_field='translated1_en')
+            self.many1.translate('ja')
+            self.many1.translated_field = 'translated1_ja'
+            self.many1.save()
+            # spurious instance to catch cases where filtering is not correct
+            obj = QOMany.objects.create(translated_field='dummy')
+            obj.translate('ja').save()
+
+    def test_reverse_foreign_key(self):
+        with LanguageOverride('en'):
+            with self.assertNumQueries(2):
+                obj = QONormal.objects.prefetch_related('simplerel').get(pk=self.qonormal_id[1])
+            with self.assertNumQueries(0):
+                self.assertEqual(len(obj.simplerel.all()), 1)
+                self.assertEqual(obj.simplerel.all()[0].pk, self.related.pk)
+                # this is the crucial part: translation should be cached, too
+                self.assertEqual(obj.simplerel.all()[0].translated_field, 'translated1_en')
+
+        with LanguageOverride('ja'):
+            with self.assertNumQueries(2):
+                obj = QONormal.objects.prefetch_related('simplerel').get(pk=self.qonormal_id[1])
+            with self.assertNumQueries(0):
+                # just checking language filter is actually applied
+                self.assertEqual(len(obj.simplerel.all()), 0)
+
+    def test_forward_many_to_many(self):
+        self.many1.normals.add(self.normal1)
+        with LanguageOverride('en'):
+            with self.assertNumQueries(2):
+                obj = QOMany.objects.prefetch_related('normals').get(pk=self.many1.pk)
+            with self.assertNumQueries(0):
+                self.assertEqual(len(obj.normals.all()), 1)
+                self.assertEqual(obj.normals.all()[0].translated_field,
+                                 QONORMAL[1].translated_field['en'])
+        with LanguageOverride('ja'):
+            with self.assertNumQueries(2):
+                obj = QOMany.objects.prefetch_related('normals').get(pk=self.many1.pk)
+            with self.assertNumQueries(0):
+                self.assertEqual(len(obj.normals.all()), 1)
+                self.assertEqual(obj.normals.all()[0].translated_field,
+                                 QONORMAL[1].translated_field['ja'])
+
+    def test_reverse_many_to_many(self):
+        self.many1.normals.add(self.normal1)
+        with LanguageOverride('en'):
+            with self.assertNumQueries(2):
+                obj = QONormal.objects.prefetch_related('manyrels').get(pk=self.qonormal_id[1])
+            with self.assertNumQueries(0):
+                self.assertEqual(len(obj.manyrels.all()), 1)
+                self.assertEqual(obj.manyrels.all()[0].translated_field,
+                                 'translated1_en')
+        with LanguageOverride('ja'):
+            with self.assertNumQueries(2):
+                obj = QONormal.objects.prefetch_related('manyrels').get(pk=self.qonormal_id[1])
+            with self.assertNumQueries(0):
+                self.assertEqual(len(obj.manyrels.all()), 1)
+                self.assertEqual(obj.manyrels.all()[0].translated_field,
+                                 'translated1_ja')


### PR DESCRIPTION
As part of a major change to the API that I would like to make possible (not decide yet) for a next major version, the goal of the PR is to make `TranslationQueryset` work as a default queryset.

Namely, this should work as expected:

``` python
class FullTranslationManager(TranslationManager):
    use_for_related_fields = True
    default_class = TranslationQueryset    # returned by Model.objects.all()
```

It does not, as of now, because it breaks when used for related fields and other auto-generated managers.
Also, the implementation should work properly with `prefetch_related` and `select_related` as well, (ref #35)
Also see the adaptations that were made in past commit 92bc942d879aac57c8e15997cefe9528e5f5fc4e. `_base_manager` and stuff.

**Update:**
Implementation is done. It also happens to implement #197.
