### PR TITLE
Django 1.8 compatibility

### DIFF
--- a/hvad/admin.py
+++ b/hvad/admin.py
@@ -280,8 +280,12 @@ class TranslatableAdmin(ModelAdmin, TranslatableModelAdminMixin):
         # will also be deleted.
         
         protected = False
-        deleted_objects, perms_needed, protected = get_deleted_objects(
-            [obj], translations_model._meta, request.user, self.admin_site, using)
+        if django.VERSION >= (1, 8):
+            deleted_objects, model_count, perms_needed, protected = get_deleted_objects(
+                [obj], translations_model._meta, request.user, self.admin_site, using)
+        else:
+            deleted_objects, perms_needed, protected = get_deleted_objects(
+                [obj], translations_model._meta, request.user, self.admin_site, using)
         
         lang = get_language_name(language_code) 
             

--- a/hvad/forms.py
+++ b/hvad/forms.py
@@ -114,7 +114,7 @@ class TranslatableModelFormMetaclass(ModelFormMetaclass):
             # Override default model fields with any custom declared ones
             # (plus, include all the other declared fields).
             fields.update(declared_fields)
-            
+
             if new_class._meta.exclude:
                 new_class._meta.exclude = list(new_class._meta.exclude)
             else:
@@ -184,8 +184,7 @@ class TranslatableModelForm(with_metaclass(TranslatableModelFormMetaclass, Model
 
         trans = construct_instance(self, trans, self._meta.fields)
         trans.language_code = language_code
-        trans.master = self.instance
-        self.instance = combine(trans, self.Meta.model)
+        setattr(self.instance, self.instance._meta.translations_cache, trans)
 
         super(TranslatableModelForm, self).save(commit=commit)
         return self.instance

--- a/hvad/models.py
+++ b/hvad/models.py
@@ -196,7 +196,6 @@ class TranslatableModel(models.Model):
         super(TranslatableModel, self).__init__(*args, **skwargs)
         # prepopulate the translations model cache with an translation model
         tkwargs['language_code'] = tkwargs.get('language_code', get_language())
-        tkwargs['master'] = self
         translated = self._meta.translations_model(*args, **tkwargs)
         setattr(self, self._meta.translations_cache, translated)
 
@@ -222,7 +221,6 @@ class TranslatableModel(models.Model):
         """
         tkwargs = {
             'language_code': language_code,
-            'master': self,
         }
         translated = self._meta.translations_model(**tkwargs)
         setattr(self, self._meta.translations_cache, translated)

--- a/hvad/tests/forms_inline.py
+++ b/hvad/tests/forms_inline.py
@@ -38,7 +38,7 @@ class TestTranslationsInline(HvadTestCase, NormalFixture):
     def test_render_formset(self):
         instance = Normal.objects.language('en').get(pk=self.normal_id[1])
         with self.assertNumQueries(1):
-            Formset = translationformset_factory(Normal, extra=1)
+            Formset = translationformset_factory(Normal, extra=1, exclude=[])
             formset = Formset(instance=instance)
             self.assertEqual(len(formset.forms), 3)
             self.assertIn('translated_field', formset.forms[0].fields)
@@ -58,7 +58,7 @@ class TestTranslationsInline(HvadTestCase, NormalFixture):
             class Form(ModelForm):
                 class Meta:
                     fields = ('translated_field',)
-            Formset = translationformset_factory(Normal, form=Form, extra=1)
+            Formset = translationformset_factory(Normal, form=Form, extra=1, exclude=[])
             formset = Formset(instance=instance)
             self.assertIn('translated_field', formset.forms[0].fields)
             self.assertIn('language_code', formset.forms[0].fields)
@@ -68,7 +68,7 @@ class TestTranslationsInline(HvadTestCase, NormalFixture):
 
     def test_create_translations(self):
         instance = Normal.objects.language('en').get(pk=self.normal_id[1])
-        Formset = translationformset_factory(Normal, extra=1)
+        Formset = translationformset_factory(Normal, extra=1, exclude=[])
 
         initial = Formset(instance=instance)
         data = FormData(initial)
@@ -85,7 +85,7 @@ class TestTranslationsInline(HvadTestCase, NormalFixture):
 
     def test_delete_translations(self):
         instance = Normal.objects.language('en').get(pk=self.normal_id[1])
-        Formset = translationformset_factory(Normal, extra=1)
+        Formset = translationformset_factory(Normal, extra=1, exclude=[])
 
         # Delete one of the two translations
         initial = Formset(instance=instance)
@@ -109,7 +109,7 @@ class TestTranslationsInline(HvadTestCase, NormalFixture):
 
     def test_mixed_update_translations(self):
         instance = Normal.objects.language('en').get(pk=self.normal_id[1])
-        Formset = translationformset_factory(Normal, extra=1)
+        Formset = translationformset_factory(Normal, extra=1, exclude=[])
 
         initial = Formset(instance=instance)
         data = FormData(initial)


### PR DESCRIPTION
Fixed most of the issues by removing the shared instance assignments to the translated instances. Apparently this didn't break anything (test are running again on 1.8 master). Not sure adding the exclude = [] to translationformset_factory makes sense. I added this to silence the "ImproperlyConfigured: Calling modelformset_factory without defining 'fields' or 'exclude' explicitly is prohibited" exceptions.
Also, get_deleted_objects() of contrib.admin.utils seems to have changed and returns an extra "model_count" param which leads to a "too many values to unpack". Added some compatibility code to handle that as well. There is still one test failing regarding language fallbacks. Maybe somebody could check that out. I verified that this still runs on latest stable (1.7.1). All tests pass there.
