### PR TITLE
TranslatableModelForm - 'NoneType' object does not support item assignment

### DIFF
--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -29,6 +29,12 @@ New features:
 - It is now possible to use :ref:`TranslationQueryset <TranslationQueryset-public>`
   as default queryset for translatable models. — :issue:`207`.
 
+Fixes:
+
+- :ref:`TranslatableModelForm <translatablemodelform>`'s
+  :meth:`~django.forms.Form.clean` can now return `None` as per the new semantics
+  introduced in Django 1.7. — :issue:`217`.
+
 .. release 0.5.1
 
 *****************************

--- a/hvad/forms.py
+++ b/hvad/forms.py
@@ -210,6 +210,8 @@ class TranslatableModelForm(with_metaclass(TranslatableModelFormMetaclass, Model
 class CleanMixin(object):
     def clean(self):
         data = super(CleanMixin, self).clean()
+        if data is None:
+            data = self.cleaned_data
         data['language_code'] = self.language
         return data
 


### PR DESCRIPTION
So i am trying to override a Admin form and according to the documentation i am supposed to a use `TranslatableModelForm`. The thing is when i start using it it loads properly but then when i press to save i get a `'NoneType' object does not support item assignment`.

This is my custom form with additional custom attributes (that are not in the model):

```
class WomenModelForm(TranslatableModelForm):
    username = forms.CharField(
        label=_('username'), max_length=30,
        help_text=_(
            'Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only.'
        ),
        validators=[
            validators.RegexValidator(
                r'^[\w.@+-]+$', _('Enter a valid username.'), 'invalid'
            )
        ])
    first_name = forms.CharField(label=_('first name'), max_length=30)
    last_name = forms.CharField(label=_('last name'), max_length=30)
    email = forms.EmailField(label=_('email address'))

    # The attribute required must be False because of the clean() workaround
    user = forms.ModelChoiceField(
        queryset=get_user_model().objects.none(), required=False
    )

    class Meta:
        model = Women
        exclude = ['image_galleries', 'video_galleries', 'avatar', 'sub_class_name']

    def __init__(self, *args, **kwargs):
        if not kwargs.get('initial'):
            kwargs['initial'] = {}

        if kwargs.get('instance'):
            kwargs['initial'].update({
                'username': kwargs['instance'].user.username,
                'first_name': kwargs['instance'].user.first_name,
                'last_name': kwargs['instance'].user.last_name,
                'email': kwargs['instance'].user.email,
            })
        super(WomenModelForm, self).__init__(*args, **kwargs)

    def clean(self):
        cleaned_data = super(WomenModelForm, self).clean()
        return clean_passport_model_form(
            instance=self.instance, errors=self._errors,
            error_class=self.error_class, cleaned_data=cleaned_data
        )
```

And this is my TranslatableAdmin:

```
class WomenAdmin(TranslatableAdmin):
    raw_id_fields = ('user', 'links',)
    # exclude = ('image_galleries', 'video_galleries', 'avatar', 'sub_class_name',)
    form = WomenModelForm

    def changeform_view(self, request, object_id=None, form_url='', extra_context=None):
        # Set Language For Translations
        user_language = request.GET.get('language')
        if user_language:
            translation.activate(user_language)

        # This view groups the images and videos for the gallery display
        extra_context = extra_context or {}
        if object_id:
            multimedia = Multimedia.objects.language()
            gallery_images = multimedia.filter(
                women_image_galleries=object_id
            )
            gallery_videos = multimedia.filter(
                women_video_galleries=object_id
            )
            extra_context['gallery_images'] = gallery_images
            extra_context['gallery_videos'] = gallery_videos

        return super(WomenAdmin, self).changeform_view(
            request, object_id=object_id, form_url=form_url,
            extra_context=extra_context
        )

admin.site.register(Women, WomenAdmin)
```

My traceback gives me:

```
Traceback:
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  111.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/contrib/admin/options.py" in wrapper
  584.                 return self.admin_site.admin_view(view)(*args, **kwargs)
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  105.                     response = view_func(request, *args, **kwargs)
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/views/decorators/cache.py" in _wrapped_view_func
  52.         response = view_func(request, *args, **kwargs)
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/contrib/admin/sites.py" in inner
  204.             return view(request, *args, **kwargs)
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/contrib/admin/options.py" in change_view
  1457.         return self.changeform_view(request, object_id, form_url, extra_context)
File "/vagrant/users/admin.py" in changeform_view
  37.             extra_context=extra_context
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapper
  29.             return bound_func(*args, **kwargs)
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  105.                     response = view_func(request, *args, **kwargs)
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/utils/decorators.py" in bound_func
  25.                 return func.__get__(self, type(self))(*args2, **kwargs2)
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/db/transaction.py" in inner
  394.                 return func(*args, **kwargs)
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/contrib/admin/options.py" in changeform_view
  1397.             if form.is_valid():
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/forms/forms.py" in is_valid
  162.         return self.is_bound and not bool(self.errors)
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/forms/forms.py" in errors
  154.             self.full_clean()
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/forms/forms.py" in full_clean
  354.         self._clean_form()
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/django/forms/forms.py" in _clean_form
  378.             cleaned_data = self.clean()
File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/hvad/forms.py" in clean
  213.         data['language_code'] = self.language

Exception Type: TypeError at /admin/users/women/2/
Exception Value: 'NoneType' object does not support item assignment
```

Any idea what i am doing wrong?
