### PR TITLE
Refactor TranslatableModelForm

### DIFF
--- a/docs/internal/forms.rst
+++ b/docs/internal/forms.rst
@@ -4,7 +4,6 @@
 
 .. module:: hvad.forms
 
-
 *******************************
 TranslatableModelFormMetaclass
 *******************************
@@ -14,48 +13,169 @@ TranslatableModelFormMetaclass
     Metaclass of :class:`TranslatableModelForm`.
 
     .. method:: __new__(cls, name, bases, attrs)
-    
-        The main thing happening in this metaclass is that the declared and base
-        fields on the form are built by calling
-        :func:`django.forms.models.fields_for_model` using the correct model
-        depending on whether the field is translated or not. This metaclass also
-        enforces the translations accessor and the master foreign key to be
-        excluded.
+
+        Uses Django's internal ``fields_for_model`` to get translated fields
+        for model and fields declarations, then lets Django handle the other
+        fields. Once it is done, it merges the translated fields, preserving order.
+
+        Special handling is done to:
+
+        * Prevent ``language_code`` from being used in any way by a field. This is
+          because the form uses the ``language_code`` key in the ``cleaned_data``
+          dictionary.
+        * Prevent ``master`` from being recognized as a translated field. It is
+          still a valid field name though.
+        * Prevent the translations accessor from being used as a field.
 
 
 **********************
 TranslatableModelForm
 **********************
 
-.. class:: TranslatableModelForm(ModelForm)
+.. class:: BaseTranslatableModelForm(BaseModelForm)
+
+        The actual class supporting the features and methods, but lacking metaclass
+        sugar. Inherited by :class:`~TranslatableModelForm` to attach the metaclass.
+        Details are documented on that class.
+
+.. class:: TranslatableModelForm(BaseTranslatableModelForm)
+
+        Main form for editing :class:`~hvad.models.TranslatableModel` instances. As with
+        regular django :class:`~django.forms.Form` classes, it can be used either
+        directly or by passing it to :func:`~translatable_modelform_factory`.
+
+        As an extension to regular forms, it handles translation and can be bound
+        to a language. Binding to a language is done by setting :attr:`language`
+        on the class (not the instance), either by inheriting it manually or
+        using the factory function. Once bound to a language, the form is in
+        **enforce** mode: all manipulations will be done using that language
+        exclusively.
 
     .. attribute:: __metaclass__
-    
+
         :class:`TranslatableModelFormMetaclass`
+
+    .. attribute:: language
+
+        The language the form is bound to. This is a class attribute. If present,
+        the form is in **enforce** mode and will only deal with the specified
+        language. See each method for the exact effects.
 
     .. method:: __init__(self, data=None, files=None, auto_id='id_%s', prefix=None, initial=None, error_class=ErrorList, label_suffix=':', empty_permitted=False, instance=None)
     
-        If this class is initialized with an instance, it updates ``initial`` to
-        also contain the data from the :term:`Translations Model` if it can be
-        found.
+        If this class is initialized with an instance, that has a translation
+        loaded, it updates ``initial`` to also contain the data from the
+        :term:`Translations Model`.
 
-    .. method:: save(self, commit=True)
-    
-        Saves both the :term:`Shared Model` and :term:`Translations Model` and
-        returns a combined model. The :term:`Translations Model` is either
-        altered if it already exists on the :term:`Shared Model` for the current
-        language (which is fetched from the ``language_code`` field on the form
-        or the current active language) or newly created.
-        
-        .. note:: Other than in a normal :class:`django.forms.ModelForm`, this
-                  method creates two queries instead of one. 
+        If the form is not bound to a language, it will use the data from the
+        instance. If the instance has no translation loaded, an attempt will be
+        made at loading the current language, and if that fails the fields will
+        be blank.
+
+        If the form is in **enforce** mode and the instance does not have the
+        correct translation loaded, then:
+
+        * it will attempt to load it from the database.
+        * if that fails, it will try to use the loaded translation on the instance.
+        * if that fails (instance is untranslated), it will use default values.
+
+        This process results in new translations being pre-populated with data
+        from another language. Simply pass an instance in that language, or an
+        untranslated instance if the behavior is not desired.
+
+    .. method:: clean(self)
+
+        If the form is in **enforce** mode, namely if it has a
+        ``language`` property, apply the it to ``cleaned_data``. As usual, the
+        special value ``None`` is replaced by current language.
+
+        If the form is not bound to a language, this method does nothing. It is
+        then possible to either use :meth:`save` in unbound mode or set the
+        language code manually in ``cleaned_data['language_code']``.
+
+        .. note:: A missing language is not the same as ``None``. While ``None``
+                  will be replaced by current language and applied to ``cleaned_data``,
+                  a missing language will not apply any language at all.
 
     .. method:: _post_clean(self)
 
-        Ensures the correct translation is loaded into **self.instance**.
-        It tries to load the language specified in the form's **language_code**
-        field from the database, and calls
-        :meth:`~hvad.models.TranslatableModel.translate` if it does not exist yet.
+        Loads a translation appropriate to the form mode. It is the very same that
+        will be loaded by :meth:`save`. Doing it twice is needed because:
+
+        * it must be done in ``_post_clean`` so that the correct translation is
+          available for modifications. For instance, if the view updates some
+          translated fields in between the call to ``is_valid()`` and ``save()``,
+          or if a form defines a custom ``save()``.
+        * it must also be done in ``save`` to ensure the language is correctly
+          enforced when in **enforce** mode.
+
+        This double check has no cost: unless the instance is changed by the view,
+        the ``save()`` check will see the translation is correct and do nothing.
+
+    .. method:: save(self, commit=True)
+
+        Saves both the :term:`Shared Model` and :term:`Translations Model` and
+        returns a combined model.
+
+        The target language is determined as follows:
+
+        * If a language is defined in ``cleaned_data``, that language is used.
+        * Else, if the instance has a translation loaded, its language is used.
+        * Else, the current language is used.
+
+        Once the language is determined, the following happen:
+
+        * If the object does not exist, it is created.
+        * If the object exists but not in the target language, its shared fields
+          are updated and a new translation is created.
+        * If the object exists in the target language, it is updated.
+
+        .. note:: The **enforce** mode has no direct impact on this method. Rather,
+                  it affects the behavior of :meth:`clean`, which places relevant
+                  language (or lack thereof) in ``cleaned_data``.
+
+    .. method:: _get_translation(self, instance, language, enforce)
+
+        The internal method :meth:`_post_clean` and :meth:`save` delegate
+        translation checks to. Note that ``enforce`` here refers to the presence
+        of a ``language_code`` in ``cleaned_data`` and not whether the form is
+        in **enforce** mode or not.
+
+        This method must gurantee that calling it on its result is a no-op.
+        Namely, in this example the second call must do nothing and return
+        the translation as is::
+
+            translation = self._get_translation(instance, language, enforce)
+            instance = combine(translation, instance.__class__)
+            translation = self._get_translation(instance, language, enforce)
+
+
+.. function:: translatable_modelform_factory(language, model, form=TranslatableModelForm, **kwargs)
+
+    Attaches a language and a model class to the specified form and returns the
+    resulting class. Additional arguments are any arguments accepted by Django's
+    :func:`~django.forms.models.modelform_factory`, including ``fields`` and
+    ``exclude``.
+
+    Having a language attached, the returned form is in **enforce** mode.
+
+.. function:: translatable_modelformset_factory(language, model, form=TranslatableModelForm, **kwargs)
+
+    Creates a formset class, allowing edition a collection of instances of ``model``,
+    all of them in the specified ``language``. Additional arguments are any
+    argument accepted by Django's :func:`~django.forms.models.modelformset_factory`.
+
+    Having a language attached, the returned formset is in **enforce** mode.
+
+.. function:: translatable_inlineformset_factory(language, parent_model, model, form=TranslatableModelForm, **kwargs)
+
+    Creates an inline formset, allowing edition of a collection of instances of
+    ``model`` attached to an instance of ``parent_model``, all of those objects
+    being in the specified ``language``. Additional arguments are any argument
+    accepted by Django's :func:`~django.forms.models.inlineformset_factory`.
+
+    Having a language attached, the returned formset is in **enforce** mode.
+
 
 **********************
 BaseTranslationFormSet

--- a/docs/public/release_notes.rst
+++ b/docs/public/release_notes.rst
@@ -20,6 +20,14 @@ Python and Django versions supported:
 
 New features:
 
+- :ref:`TranslatableModelForm <translatablemodelform>` has been refactored to make
+  its behavior more consistent. As a result, it exposes two distinct language
+  selection modes, *normal* and *enforce*, and has a clear API for manually
+  overriding the language — :issue:`221`.
+- The new features of :func:`~django.forms.models.modelform_factory` introduced by
+  Django 1.6 and 1.7 are now available on
+  :ref:`translatable_modelform_factory <translatablemodelformfactory>` as
+  well — :issue:`221`.
 - :ref:`TranslationQueryset <TranslationQueryset-public>` now has a
   :ref:`fallbacks() <fallbacks-public>` method when running on
   Django 1.6 or newer, allowing the queryset to use fallback languages while
@@ -28,6 +36,18 @@ New features:
   :meth:`~django.db.models.query.QuerySet.extra` is now supported. — :issue:`207`.
 - It is now possible to use :ref:`TranslationQueryset <TranslationQueryset-public>`
   as default queryset for translatable models. — :issue:`207`.
+
+Compatibility warnings:
+
+- :ref:`TranslatableModelForm <translatablemodelform>` has been refactored to make
+  its behavior more consistent. The core API has not changed, but edge cases are
+  now clearly specified and some inconsistencies have disappeared, which could
+  create issues, especially:
+
+  - Direct use of the form class, without passing through the
+    :ref:`factory method <translatablemodelformfactory>`. This used to have an
+    unspecified behavior regarding language selection. Behavior is now
+    well-defined. Please ensure it works the way you expect it to.
 
 Fixes:
 

--- a/hvad/tests/__init__.py
+++ b/hvad/tests/__init__.py
@@ -17,7 +17,8 @@ if django.VERSION < (1, 6): # Starting from django 1.6 we use DiscoverRunner ins
                                       FallbackValuesTests, FallbackInBulkTests,
                                       FallbackNotImplementedTests)
     from hvad.tests.fieldtranslator import FieldtranslatorTests
-    from hvad.tests.forms import FormTests
+    from hvad.tests.forms import (FormDeclarationTests, FormInstantiationTests,
+                                  FormValidationTests, FormCommitTests, FormsetTests)
     from hvad.tests.ordering import OrderingTest, DefaultOrderingTest
     from hvad.tests.query import (FilterTests, ExtraTests, QueryCachingTests, IterTests, UpdateTests,
         ValuesListTests, ValuesTests, InBulkTests, DeleteTests, GetTranslationFromInstanceTests,

--- a/hvad/tests/admin.py
+++ b/hvad/tests/admin.py
@@ -502,11 +502,11 @@ class AdminNoFixturesTests(HvadTestCase, BaseAdminTests):
     def test_translatable_modelform_factory(self):
         t = translatable_modelform_factory('en', Normal, fields=['shared_field'], exclude=['id'])
         self.assertEqual(t.Meta.fields, ['shared_field'])
-        self.assertEqual(t.Meta.exclude, ['id', 'language_code'])
+        self.assertEqual(t.Meta.exclude, ['id', 'language_code', 'translations'])
         
         t = translatable_modelform_factory('en', Normal, fields=['shared_field'], exclude=['id'])
         self.assertEqual(t.Meta.fields, ['shared_field'])
-        self.assertEqual(t.Meta.exclude, ['id', 'language_code'])
+        self.assertEqual(t.Meta.exclude, ['id', 'language_code', 'translations'])
         
         class TestForm(TranslatableModelForm):
             class Meta:
@@ -515,7 +515,7 @@ class AdminNoFixturesTests(HvadTestCase, BaseAdminTests):
                
         t = translatable_modelform_factory('en', Normal, form=TestForm)
         self.assertEqual(t.Meta.fields, ['shared_field'])
-        self.assertEqual(t.Meta.exclude, ['id', 'language_code'])
+        self.assertEqual(t.Meta.exclude, ['id', 'language_code', 'translations'])
         
 
 class AdminRelationTests(HvadTestCase, BaseAdminTests, SuperuserFixture, NormalFixture):

--- a/hvad/tests/forms.py
+++ b/hvad/tests/forms.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
+import django
 from django.core.exceptions import FieldError
-from hvad.forms import (TranslatableModelForm, TranslatableModelFormMetaclass,
-                        translatable_modelform_factory)
+from hvad.forms import (TranslatableModelForm,
+                        translatable_modelform_factory, translatable_modelformset_factory)
+from hvad.utils import get_cached_translation
 from hvad.test_utils.context_managers import LanguageOverride
 from hvad.test_utils.testcase import HvadTestCase
-from hvad.test_utils.project.app.models import Normal, SimpleRelated
+from hvad.test_utils.project.app.models import Normal, SimpleRelated, Standard
 from hvad.test_utils.data import NORMAL
 from hvad.test_utils.fixtures import NormalFixture
-from django.db import models
 from django import forms
+
+#=============================================================================
 
 class NormalForm(TranslatableModelForm):
     class Meta:
@@ -24,10 +27,16 @@ class NormalMediaForm(TranslatableModelForm):
             'all': ('layout.css',)
         }
 
-class NormalFormExclude(TranslatableModelForm):
+class CustomLanguageNormalForm(NormalForm):
+    def clean(self):
+        data = super(CustomLanguageNormalForm, self).clean()
+        data['seen_language'] = data.get('language_code')
+        data['language_code'] = 'sr'
+        return data
+
     class Meta:
         model = Normal
-        exclude = ['shared_field']
+        fields = ['shared_field', 'translated_field']
 
 class SimpleRelatedForm(TranslatableModelForm):
     normal = forms.ModelChoiceField(queryset=Normal.objects.language())
@@ -35,168 +44,491 @@ class SimpleRelatedForm(TranslatableModelForm):
         model = SimpleRelated
         fields = ['normal', 'translated_field']
 
-class NoneCleanForm(TranslatableModelForm):
-    def clean(self):
-        super(NoneCleanForm, self).clean()
-        pass # do not return cleaned_data, this is valid starting from Django 1.7
+
+#=============================================================================
+
+class FormDeclarationTests(HvadTestCase):
+    'Mostly metaclass and factory tests'
+
+    def test_no_meta(self):
+        'Empty form and filled in variant from factory'
+        class Form(TranslatableModelForm):
+            pass
+        self.assertIs(Form._meta.fields, None)
+        self.assertCountEqual(Form._meta.exclude, ['language_code'])
+        self.assertCountEqual(Form.base_fields, [])
+
+        engineered = translatable_modelform_factory('en', Normal, form=Form)
+        self.assertIs(Form._meta.fields, None)
+        self.assertCountEqual(engineered._meta.exclude, ['language_code', 'translations'])
+        self.assertCountEqual(engineered.base_fields, ['shared_field', 'translated_field'])
+
+    def test_only_model(self):
+        'Standalone form with model in Meta'
+        class Form(TranslatableModelForm):
+            class Meta:
+                model = Normal
+        self.assertIs(Form._meta.fields, None)
+        self.assertCountEqual(Form._meta.exclude, ['language_code', 'translations'])
+        self.assertCountEqual(Form.base_fields, ['shared_field', 'translated_field'])
+
+    def test_only_fields(self):
+        'Empty form and filled in variant from factory - applies field restriction'
+        class Form(TranslatableModelForm):
+            class Meta:
+                fields = ('shared_field', 'translated_field')
+        self.assertCountEqual(Form._meta.fields, ['shared_field', 'translated_field'])
+        self.assertCountEqual(Form._meta.exclude, ['language_code'])
+        self.assertCountEqual(Form.base_fields, [])
+
+        engineered = translatable_modelform_factory('en', Normal, form=Form)
+        self.assertCountEqual(engineered._meta.fields, ['shared_field', 'translated_field'])
+        self.assertCountEqual(engineered._meta.exclude, ['language_code', 'translations'])
+        self.assertCountEqual(engineered.base_fields, ['shared_field', 'translated_field'])
+
+    def test_model_and_fields(self):
+        'Standalone form with model in Meta and field restrictions'
+        class Form1(TranslatableModelForm):     # merged fields
+            class Meta:
+                model = Normal
+                fields = ('shared_field', 'translated_field')
+        self.assertCountEqual(Form1._meta.fields, ['shared_field', 'translated_field'])
+        self.assertCountEqual(Form1._meta.exclude, ['language_code', 'translations'])
+        self.assertCountEqual(Form1.base_fields, ['shared_field', 'translated_field'])
+
+        class Form2(TranslatableModelForm):     # only shared fields
+            class Meta:
+                model = Normal
+                fields = ('shared_field',)
+        self.assertCountEqual(Form2._meta.fields, ['shared_field'])
+        self.assertCountEqual(Form2._meta.exclude, ['language_code', 'translations'])
+        self.assertCountEqual(Form2.base_fields, ['shared_field'])
+
+        class Form3(TranslatableModelForm):     # only translated fields
+            class Meta:
+                model = Normal
+                fields = ('translated_field',)
+        self.assertCountEqual(Form3._meta.fields, ['translated_field'])
+        self.assertCountEqual(Form3._meta.exclude, ['language_code', 'translations'])
+        self.assertCountEqual(Form3.base_fields, ['translated_field'])
+
+        with self.assertRaises(FieldError):     # invalid fields
+            class Form4(TranslatableModelForm):
+                class Meta:
+                    model = Normal
+                    fields = ('nonexistent',)
+
+    def test_special_fields(self):
+        'Special handling of master, language_code and translation accessor'
+        # language_code is a reserved field name
+        with self.assertRaises(FieldError):
+            class Form1(TranslatableModelForm):
+                class Meta:
+                    fields = ('shared_model', 'language_code')
+        # translation accessor would wreak havoc on the model
+        with self.assertRaises(FieldError):
+            class Form2(TranslatableModelForm):
+                class Meta:
+                    model = Normal
+                    fields = ('shared_mode', Normal._meta.translations_accessor)
+        # master is a valid shared field, but translation's master should be concealed
+        with self.assertRaises(FieldError):
+            class Form3(TranslatableModelForm):
+                class Meta:
+                    model = Normal
+                    fields = ('shared_model', 'master')
+
+    def test_invalid_model(self):
+        'Check that TranslatableModelForm does not accept regular models'
+        self.assertRaises(TypeError, translatable_modelform_factory, 'en', Standard)
 
 
-class FormTests(HvadTestCase, NormalFixture):
+#=============================================================================
+
+class FormInstantiationTests(HvadTestCase, NormalFixture):
+    'Form initialization and rendering from instance and initial data'
     normal_count = 2
 
-    def test_nontranslatablemodelform(self):
-        # Make sure that TranslatableModelForm won't accept a regular model
-
-        # "Fake" model to use for the TranslatableModelForm
-        class NonTranslatableModel(models.Model):
-            field = models.CharField(max_length=128)
-        # Meta class for use below
-        class Meta:
-            model = NonTranslatableModel
-            exclude = []
-        # Make sure we do indeed get an exception, if we try to initialise it
-        self.assertRaises(TypeError,
-            TranslatableModelFormMetaclass,
-            'NonTranslatableModelForm', (TranslatableModelForm,),
-            {'Meta': Meta}
-        )
-
-    def test_normal_model_form_instantiation(self):
-        # Basic example and checking it gives us all the fields needed
+    def test_empty(self):
         form = NormalForm()
-        self.assertTrue("translated_field" in form.fields)
-        self.assertTrue("shared_field" in form.fields)
-        self.assertTrue("translated_field" in form.base_fields)
-        self.assertTrue("shared_field" in form.base_fields)
+        self.assertCountEqual(form.fields, ['shared_field', 'translated_field'])
         self.assertFalse(form.is_valid())
+        with self.assertThrowsWarning(DeprecationWarning):
+            self.assertRaises(ValueError, form.save)
 
-        # Check if it works with media argument too
         form = NormalMediaForm()
+        self.assertCountEqual(form.fields, ['shared_field', 'translated_field'])
         self.assertFalse(form.is_valid())
-        self.assertTrue("layout.css" in str(form.media))
-
-        # Check if it works with an instance of Normal
-        form = NormalForm(instance=Normal())
-        self.assertFalse(form.is_valid())
-
-    def test_normal_model_form_valid(self):
-        SHARED = 'Shared'
-        TRANSLATED = 'English'
-        data = {
-            'shared_field': SHARED,
-            'translated_field': TRANSLATED,
-            'language_code': 'en'
-        }
-        form = NormalForm(data)
-        self.assertTrue(form.is_valid(), form.errors.as_text())
-        self.assertTrue("translated_field" in form.fields)
-        self.assertTrue("shared_field" in form.fields)
-        self.assertTrue(TRANSLATED in form.clean()["translated_field"])
-        self.assertTrue(SHARED in form.clean()["shared_field"])
-
-    def test_normal_model_form_initaldata_instance(self):
-        # Check if it accepts inital data and instance
-        SHARED = 'Shared'
-        TRANSLATED = 'English'
-        data = {
-            'shared_field': SHARED,
-            'translated_field': TRANSLATED,
-            'language_code': 'en'
-        }
-        form = NormalForm(data, instance=Normal(), initial=data)
-        self.assertTrue(form.is_valid(), form.errors.as_text())
-
-    def test_normal_model_form_existing_instance(self):
-        # Check if it works with an existing instance of Normal
-        SHARED = 'Shared'
-        TRANSLATED = 'English'
-        instance = Normal.objects.language("en").create(
-            shared_field=SHARED, translated_field=TRANSLATED
-        )
-        form = NormalForm(instance=instance)
-        self.assertFalse(form.is_valid())
-        self.assertTrue(SHARED in form.as_p())
-        self.assertTrue(TRANSLATED in form.as_p())
-
-    def test_normal_model_form_save(self):
-        with LanguageOverride('en'):
-            SHARED = 'Shared'
-            TRANSLATED = 'English'
-            data = {
-                'shared_field': SHARED,
-                'translated_field': TRANSLATED,
-                'language_code': 'en'
-            }
-            form = NormalForm(data)
-            # tested a non-translated ModelForm, and that takes 7 queries.
-            with self.assertNumQueries(2):
-                obj = form.save()
-            with self.assertNumQueries(0):
-                self.assertEqual(obj.shared_field, SHARED)
-                self.assertEqual(obj.translated_field, TRANSLATED)
-                self.assertNotEqual(obj.pk, None)
-
-    def test_normal_model_form_save_nocommit(self):
-        with LanguageOverride('en'):
-            SHARED = 'Shared'
-            TRANSLATED = 'English'
-            data = {
-                'shared_field': SHARED,
-                'translated_field': TRANSLATED,
-                'language_code': 'en'
-            }
-            form = NormalForm(data)
-            # tested a non-translated ModelForm, and that takes 7 queries.
-            with self.assertNumQueries(0):
-                obj = form.save(commit=False)
-                self.assertEqual(obj.shared_field, SHARED)
-                self.assertEqual(obj.translated_field, TRANSLATED)
-                self.assertEqual(obj.pk, None)
-            with self.assertNumQueries(2):
-                obj.save()
-                self.assertEqual(obj.shared_field, SHARED)
-                self.assertEqual(obj.translated_field, TRANSLATED)
-                self.assertNotEqual(obj.pk, None)
-
-    def test_no_language_code_in_fields(self):
-        with LanguageOverride("en"):
-            form = NormalForm()
-            self.assertFalse("language_code" in form.fields)
-
-            form = NormalMediaForm()
-            self.assertFalse("language_code" in form.fields)
-
-            form = NormalFormExclude()
-            self.assertFalse("language_code" in form.fields)
-
-    def test_form_wrong_field_in_class(self):
-        with LanguageOverride("en"):
-            def create_wrong_form():
-                class WrongForm(TranslatableModelForm):
-                    class Meta:
-                        model = Normal
-                        fields = ['a_field_that_doesnt_exist']
-            self.assertRaises(FieldError, create_wrong_form)
+        self.assertIn('layout.css', str(form.media))
 
     def test_simple_related_form(self):
         with LanguageOverride('en'):
             form = SimpleRelatedForm()
             rendered = form['normal'].as_widget()
-            self.assertIn(NORMAL[1].translated_field['en'], rendered)
-            self.assertIn(NORMAL[2].translated_field['en'], rendered)
+            for index in self.normal_id:
+                self.assertIn(NORMAL[index].translated_field['en'], rendered)
 
         with LanguageOverride('ja'):
             form = SimpleRelatedForm()
             rendered = form['normal'].as_widget()
-            self.assertIn(NORMAL[1].translated_field['ja'], rendered)
-            self.assertIn(NORMAL[2].translated_field['ja'], rendered)
+            for index in self.normal_id:
+                self.assertIn(NORMAL[index].translated_field['ja'], rendered)
 
-    def test_accepts_none_clean(self):
-        Form = translatable_modelform_factory('en', Normal, form=NoneCleanForm,
-                                              fields=['shared_field', 'translated_field'])
+    def test_instance(self):
+        # no language enforced
+        with self.assertNumQueries(1):
+            form = NormalForm(instance=Normal.objects.language('ja').get(pk=self.normal_id[1]))
+        self.assertFalse(form.is_valid())
+        self.assertCountEqual(form.initial, ['shared_field', 'translated_field'])
+        self.assertEqual(form.initial['shared_field'], NORMAL[1].shared_field)
+        self.assertEqual(form.initial['translated_field'], NORMAL[1].translated_field['ja'])
+        self.assertIn('value="%s"' % NORMAL[1].shared_field, form.as_p())
+        self.assertIn('value="%s"' % NORMAL[1].translated_field['ja'], form.as_p())
+        self.assertEqual(get_cached_translation(form.instance).language_code, 'ja')
+
+        # enforce japanese language
+        with self.assertNumQueries(1):
+            Form = translatable_modelform_factory('ja', Normal, form=NormalForm)
+            form = Form(instance=Normal.objects.language('ja').get(pk=self.normal_id[1]))
+        self.assertFalse(form.is_valid())
+        self.assertCountEqual(form.initial, ['shared_field', 'translated_field'])
+        self.assertEqual(form.initial['shared_field'], NORMAL[1].shared_field)
+        self.assertEqual(form.initial['translated_field'], NORMAL[1].translated_field['ja'])
+        self.assertIn('value="%s"' % NORMAL[1].shared_field, form.as_p())
+        self.assertIn('value="%s"' % NORMAL[1].translated_field['ja'], form.as_p())
+        self.assertEqual(get_cached_translation(form.instance).language_code, 'ja')
+
+    def test_instance_untranslated(self):
+        # no language enforced, should load anyway
+        with LanguageOverride('en'):
+            form = NormalForm(instance=Normal.objects.untranslated().get(pk=self.normal_id[1]))
+        self.assertFalse(form.is_valid())
+        self.assertCountEqual(form.initial, ['shared_field', 'translated_field'])
+        self.assertEqual(form.initial['shared_field'], NORMAL[1].shared_field)
+        self.assertEqual(form.initial['translated_field'], NORMAL[1].translated_field['en'])
+        self.assertIn('value="%s"' % NORMAL[1].shared_field, form.as_p())
+        self.assertIn('value="%s"' % NORMAL[1].translated_field['en'], form.as_p())
+        self.assertIs(get_cached_translation(form.instance), None)
+
+        # enforce japanese language
+        with LanguageOverride('en'):
+            Form = translatable_modelform_factory('ja', Normal, form=NormalForm)
+            form = Form(instance=Normal.objects.untranslated().get(pk=self.normal_id[1]))
+        self.assertFalse(form.is_valid())
+        self.assertCountEqual(form.initial, ['shared_field', 'translated_field'])
+        self.assertEqual(form.initial['shared_field'], NORMAL[1].shared_field)
+        self.assertEqual(form.initial['translated_field'], NORMAL[1].translated_field['ja'])
+        self.assertIn('value="%s"' % NORMAL[1].shared_field, form.as_p())
+        self.assertIn('value="%s"' % NORMAL[1].translated_field['ja'], form.as_p())
+        self.assertIs(get_cached_translation(form.instance), None)
+
+    def test_instance_wrong_translation(self):
+        # no language enforced
+        form = NormalForm(instance=Normal.objects.language('en').get(pk=self.normal_id[1]))
+        self.assertFalse(form.is_valid())
+        self.assertCountEqual(form.initial, ['shared_field', 'translated_field'])
+        self.assertEqual(form.initial['shared_field'], NORMAL[1].shared_field)
+        self.assertEqual(form.initial['translated_field'], NORMAL[1].translated_field['en'])
+        self.assertIn('value="%s"' % NORMAL[1].shared_field, form.as_p())
+        self.assertIn('value="%s"' % NORMAL[1].translated_field['en'], form.as_p())
+        self.assertEqual(get_cached_translation(form.instance).language_code, 'en')
+
+        # enforce japanese language
+        Form = translatable_modelform_factory('ja', Normal, form=NormalForm)
+        form = Form(instance=Normal.objects.language('en').get(pk=self.normal_id[1]))
+        self.assertFalse(form.is_valid())
+        self.assertCountEqual(form.initial, ['shared_field', 'translated_field'])
+        self.assertEqual(form.initial['shared_field'], NORMAL[1].shared_field)
+        self.assertEqual(form.initial['translated_field'], NORMAL[1].translated_field['ja'])
+        self.assertIn('value="%s"' % NORMAL[1].shared_field, form.as_p())
+        self.assertIn('value="%s"' % NORMAL[1].translated_field['ja'], form.as_p())
+        self.assertEqual(get_cached_translation(form.instance).language_code, 'en')
+
+    def test_instance_initial(self):
+        Form = translatable_modelform_factory('ja', Normal, form=NormalForm)
+        initial = {
+            'shared_field': 'shared_initial',
+            'translated_field': 'translated_initial',
+        }
+        form = Form(instance=Normal.objects.language('ja').get(pk=self.normal_id[1]),
+                    initial=initial)
+        self.assertFalse(form.is_valid())
+        self.assertCountEqual(form.initial, ['shared_field', 'translated_field'])
+        self.assertEqual(form.initial['shared_field'], 'shared_initial')
+        self.assertEqual(form.initial['translated_field'], 'translated_initial')
+
+
+#=============================================================================
+
+class FormValidationTests(HvadTestCase, NormalFixture):
+    'Testing form cleaning, especially the language_code with various settings'
+    normal_count = 1
+
+    def test_basic(self):
+        'Basic form with data, should validate and set cleaned_data'
         data = {
             'shared_field': 'shared',
             'translated_field': 'English',
         }
-        form = Form(data, instance=Normal(), initial=data)
+        form = NormalForm(data)
         self.assertTrue(form.is_valid(), form.errors.as_text())
+        self.assertCountEqual(form.cleaned_data, ['shared_field', 'translated_field'])
+        self.assertEqual(form.cleaned_data['shared_field'], 'shared')
+        self.assertEqual(form.cleaned_data['translated_field'], 'English')
+
+    def test_instance(self):
+        'Having an instance attached should not prevent normal working of the form'
+        data = {
+            'shared_field': 'shared',
+            'translated_field': 'English',
+        }
+        form = NormalForm(data, instance=Normal.objects.language('en').get(pk=self.normal_id[1]))
+        self.assertTrue(form.is_valid(), form.errors.as_text())
+        self.assertCountEqual(form.cleaned_data, ['shared_field', 'translated_field'])
+        self.assertEqual(form.cleaned_data['shared_field'], 'shared')
+        self.assertEqual(form.cleaned_data['translated_field'], 'English')
+
+    def test_language_code_not_enforcing(self):
+        'Language code is not a field, it should not be in cleaned data by default'
+        data = {
+            'shared_field': 'shared',
+            'translated_field': 'Japanese',
+            'language_code': 'ja',
+        }
+        form = NormalForm(data)
+        self.assertTrue(form.is_valid(), form.errors.as_text())
+        self.assertCountEqual(form.cleaned_data, ['shared_field', 'translated_field'])
+
+        form = CustomLanguageNormalForm(data)
+        self.assertTrue(form.is_valid(), form.errors.as_text())
+        self.assertCountEqual(form.cleaned_data, ['shared_field', 'translated_field',
+                                                  'seen_language', 'language_code'])
+        self.assertIs(form.cleaned_data['seen_language'], None)
+        self.assertEqual(form.cleaned_data['language_code'], 'sr')
+
+    def test_language_code_enforcing(self):
+        'With language_code enforcing, language should be set automatically'
+        Form = translatable_modelform_factory('ja', Normal, form=NormalForm)
+        data = {
+            'shared_field': 'shared',
+            'translated_field': 'Japanese',
+        }
+        form = Form(data)
+        self.assertTrue(form.is_valid(), form.errors.as_text())
+        self.assertCountEqual(form.cleaned_data, ['shared_field', 'translated_field', 'language_code'])
+        self.assertEqual(form.cleaned_data['language_code'], 'ja')
+
+        data = {
+            'shared_field': 'shared',
+            'translated_field': 'Japanese',
+            'language_code': 'sr',
+        }
+        Form = translatable_modelform_factory('ja', Normal, form=NormalForm)
+        form = Form(data)
+        self.assertTrue(form.is_valid(), form.errors.as_text())
+        self.assertCountEqual(form.cleaned_data, ['shared_field', 'translated_field', 'language_code'])
+        self.assertEqual(form.cleaned_data['language_code'], 'ja')
+
+    def test_language_code_enforcing_override(self):
+        'Custom clean() method should see language_code and be able to override it'
+        Form = translatable_modelform_factory('ja', Normal, form=CustomLanguageNormalForm)
+        data = {
+            'shared_field': 'shared',
+            'translated_field': 'Japanese',
+        }
+        form = Form(data)
+        self.assertTrue(form.is_valid(), form.errors.as_text())
+        self.assertCountEqual(form.cleaned_data, ['shared_field', 'translated_field',
+                                                  'seen_language', 'language_code'])
+        self.assertIs(form.cleaned_data['seen_language'], 'ja')
+        self.assertEqual(form.cleaned_data['language_code'], 'sr')
+
+
+#=============================================================================
+
+class FormCommitTests(HvadTestCase, NormalFixture):
+    normal_count = 2
+
+    def test_create_not_enforcing(self):
+        'Calling save on a new instance with no language_code in cleaned_data'
+        data = {
+            'shared_field': 'shared',
+            'translated_field': u'српски',
+        }
+        # no instance, should use current language
+        with LanguageOverride('sr'):
+            form = NormalForm(data)
+            with self.assertNumQueries(2):
+                obj = form.save()
+            with self.assertNumQueries(0):
+                self.assertNotEqual(obj.pk, None)
+                self.assertEqual(obj.language_code, 'sr')
+                self.assertEqual(obj.shared_field, 'shared')
+                self.assertEqual(obj.translated_field, u'српски')
+
+        # an instance with a translation loaded, should use that
+        with LanguageOverride('en'):
+            form = NormalForm(data, instance=Normal(language_code='sr'))
+            with self.assertNumQueries(2):
+                obj = form.save()
+            with self.assertNumQueries(0):
+                self.assertNotEqual(obj.pk, None)
+                self.assertEqual(obj.language_code, 'sr')
+                self.assertEqual(obj.shared_field, 'shared')
+                self.assertEqual(obj.translated_field, u'српски')
+
+    def test_create_enforcing(self):
+        'Calling save() on a new instance with a language_code in cleaned_data'
+        Form = translatable_modelform_factory('ja', Normal, form=NormalForm)
+        data = {
+            'shared_field': 'shared',
+            'translated_field': 'Japanese',
+        }
+        with LanguageOverride('en'):
+            form = Form(data, instance=Normal(language_code='sr'))
+            with self.assertNumQueries(2):
+                obj = form.save()
+            with self.assertNumQueries(0):
+                self.assertNotEqual(obj.pk, None)
+                self.assertEqual(obj.language_code, 'ja')
+                self.assertEqual(obj.shared_field, 'shared')
+                self.assertEqual(obj.translated_field, 'Japanese')
+
+    def test_update_not_enforcing(self):
+        'Calling save on an existing instance with no language_code in cleaned_data'
+        data = {
+            'shared_field': 'shared',
+            'translated_field': 'translated',
+        }
+        with LanguageOverride('en'):
+            # translation is loaded, use it
+            form = NormalForm(data, instance=Normal.objects.language('ja').get(pk=self.normal_id[1]))
+            with self.assertNumQueries(2 if django.VERSION >= (1, 6) else 4):
+                obj = form.save()
+            with self.assertNumQueries(0):
+                self.assertEqual(obj.pk, self.normal_id[1])
+                self.assertEqual(obj.language_code, 'ja')
+                self.assertEqual(obj.shared_field, 'shared')
+                self.assertEqual(obj.translated_field, 'translated')
+            self.assertEqual(Normal.objects.language('ja').get(pk=self.normal_id[1]).translated_field,
+                             'translated')
+
+            # no translation loaded, use current language
+            form = NormalForm(data, instance=Normal.objects.untranslated().get(pk=self.normal_id[1]))
+            with self.assertNumQueries(3 if django.VERSION >= (1, 6) else 5):
+                obj = form.save()
+            with self.assertNumQueries(0):
+                self.assertEqual(obj.pk, self.normal_id[1])
+                self.assertEqual(obj.language_code, 'en')
+                self.assertEqual(obj.shared_field, 'shared')
+                self.assertEqual(obj.translated_field, 'translated')
+            self.assertEqual(Normal.objects.language('en').get(pk=self.normal_id[1]).translated_field,
+                             'translated')
+
+            # new translation is loaded, use it
+            obj.translate('sr')
+            form = NormalForm(data, instance=obj)
+            with self.assertNumQueries(2 if django.VERSION >= (1, 6) else 3):
+                obj = form.save()
+            with self.assertNumQueries(0):
+                self.assertEqual(obj.pk, self.normal_id[1])
+                self.assertEqual(obj.language_code, 'sr')
+                self.assertEqual(obj.shared_field, 'shared')
+                self.assertEqual(obj.translated_field, 'translated')
+            self.assertEqual(Normal.objects.language('sr').get(pk=self.normal_id[1]).translated_field,
+                             'translated')
+
+    def test_update_enforcing(self):
+        'Calling save on an existing instance, with a language_code in cleaned_data'
+        Form = translatable_modelform_factory('sr', Normal, form=NormalForm)
+        data = {
+            'shared_field': 'shared',
+            'translated_field': u'српски',
+        }
+        with LanguageOverride('en'):
+            # wrong translation is loaded, override it
+            form = Form(data, instance=Normal.objects.language('ja').get(pk=self.normal_id[1]))
+            with self.assertNumQueries(3 if django.VERSION >= (1, 6) else 4):
+                obj = form.save()
+            with self.assertNumQueries(0):
+                self.assertEqual(obj.pk, self.normal_id[1])
+                self.assertEqual(obj.language_code, 'sr')
+                self.assertEqual(obj.shared_field, 'shared')
+                self.assertEqual(obj.translated_field, u'српски')
+            self.assertEqual(Normal.objects.language('sr').get(pk=self.normal_id[1]).translated_field,
+                             u'српски')
+
+    def test_set_fields_before_save(self):
+        'Manually set some translated fields before calling save()'
+        Form = translatable_modelform_factory('sr', Normal, form=NormalForm,
+                                              exclude=['translated_field'])
+        data = {
+            'shared_field': 'shared',
+        }
+        with LanguageOverride('en'):
+            form = Form(data, instance=Normal.objects.language('ja').get(pk=self.normal_id[1]))
+            with self.assertNumQueries(1):
+                self.assertTrue(form.is_valid())
+            form.instance.translated_field = u'ћирилица'
+            with self.assertNumQueries(2 if django.VERSION >= (1, 6) else 3):
+                obj = form.save()
+            with self.assertNumQueries(0):
+                self.assertEqual(obj.pk, self.normal_id[1])
+                self.assertEqual(obj.language_code, 'sr')
+                self.assertEqual(obj.shared_field, 'shared')
+                self.assertEqual(obj.translated_field, u'ћирилица')
+            self.assertEqual(Normal.objects.language('sr').get(pk=self.normal_id[1]).translated_field,
+                             u'ћирилица')
+
+    def test_nocommit(self):
+        'The commit=False should be properly honored'
+        with LanguageOverride('en'):
+            data = {
+                'shared_field': 'shared',
+                'translated_field': 'English',
+            }
+            form = NormalForm(data)
+            with self.assertNumQueries(0):
+                obj = form.save(commit=False)
+                self.assertEqual(obj.shared_field, 'shared')
+                self.assertEqual(obj.translated_field, 'English')
+                self.assertIs(obj.pk, None)
+            with self.assertNumQueries(2):
+                obj.save()
+                self.assertEqual(obj.shared_field, 'shared')
+                self.assertEqual(obj.translated_field, 'English')
+                self.assertIsNot(obj.pk, None)
+
+
+#=============================================================================
+
+class FormsetTests(HvadTestCase, NormalFixture):
+    'Very light parameter passing tests as we just forward calls to Django'
+    normal_count = 0
+
+    def test_create_formset(self):
+        kwargs = {
+            'form': NormalForm,
+            'extra': 1,
+            'can_delete': True,
+            'can_order': False,
+            'max_num': 5,
+            'fields': ('translated_field',)
+        }
+        if django.VERSION >= (1, 6):
+            kwargs['validate_max'] = True
+            kwargs['labels'] = {
+                'shared_field': 'Shared Field',
+                'translated_field': 'Translated Field',
+            }
+            kwargs['help_texts'] = {
+                'shared_field': 'This is a field shared amongst languages',
+                'translated_field': 'This field is specific to a language',
+            }
+            kwargs['localized_fields'] = ['translated_field']
+        formset = translatable_modelformset_factory('en', Normal, **kwargs)
+        self.assertTrue(issubclass(formset.form, NormalForm))
+
+    def test_unknown_argument(self):
+        self.assertRaises(TypeError, translatable_modelformset_factory,
+                          'en', Normal, nonexistent='dummy')

--- a/hvad/tests/forms_inline.py
+++ b/hvad/tests/forms_inline.py
@@ -67,7 +67,7 @@ class TestTranslationsInline(HvadTestCase, NormalFixture):
             self.assertNotIn('master', formset.forms[0].fields)
 
     def test_create_translations(self):
-        instance = Normal.objects.language('en').get(pk=self.normal_id[1])
+        instance = Normal.objects.untranslated().get(pk=self.normal_id[1])
         Formset = translationformset_factory(Normal, extra=1)
 
         initial = Formset(instance=instance)


### PR DESCRIPTION
This is the long due rehauling of `TranslatableModelForm`.
It is basically a 2-step rewrite:
- First I rewrote the code, making sure it passed existing tests
- Then I rewrote the tests to be much more thorough (25 additional tests, 100% test coverage, almost 100% branch coverage).

The API has not changed, so no major backward incompatibilities have been introduced. Some edge cases that were inconsistent have been made consistent though, which could create some glitches with existing code relying on those inconsistencies. In the end, a lot of the logic has been handed back to Django so `TranslatableModelForm` behaves in an entirely boring, unsurprising way.

It is here for a bit of testing while it waits for me to "refactor" the documentation too.
