### PR TITLE
UnicodeDecodeError: when installing with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup, find_packages
 from hvad import __version__ as version
 
-with open('README.rst', encoding='utf-8') as f:
-    long_description = f.read()
+with open('README.rst', 'rb') as f:
+    long_description = f.read().decode('utf-8')
 
 setup(
     name = 'django-hvad',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from hvad import __version__ as version
 
-with open('README.rst') as f:
+with open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
On some systems where default locale character encoding is not UTF-8 (or ASCII, haven't tried other), the setup script fails.

    Downloading/unpacking django-hvad==1.2.0 (from -r /var/www/app/requirements.txt (line 6))
      Running setup.py (path:/var/www/env/build/django-hvad/setup.py) egg_info for package django-hvad
        Traceback (most recent call last):
          File "<string>", line 17, in <module>
          File "/var/www/env/build/django-hvad/setup.py", line 5, in <module>
            long_description = f.read()
          File "/var/www/env/lib/python3.4/encodings/ascii.py", line 26, in decode
            return codecs.ascii_decode(input, self.errors)[0]
        UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1744: ordinal not in range(128)
        Complete output from command python setup.py egg_info:
        Traceback (most recent call last):

      File "<string>", line 17, in <module>

      File "/var/www/env/build/django-hvad/setup.py", line 5, in <module>

        long_description = f.read()

      File "/var/www/env/lib/python3.4/encodings/ascii.py", line 26, in decode

        return codecs.ascii_decode(input, self.errors)[0]

    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1744: ordinal not in range(128)

I had this box running with ANSI_X3.4-1968 encoding:
    Python 3.4.0 (default, Apr 11 2014, 13:05:11) 
    [GCC 4.8.2] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import locale
    >>> locale.getpreferredencoding(False)
    'ANSI_X3.4-1968'

Python3 implicitly assumes the encoding 'ascii'. We need to explicitly state the encoding.