### PR TITLE
Missing return statement in SmartGetField (utils.py)

### DIFF
--- a/hvad/utils.py
+++ b/hvad/utils.py
@@ -126,7 +126,7 @@ class SmartGetField(object):
             return self.real(name, *args, **kwargs)
         except FieldDoesNotExist as e:
             try:
-                meta.translations_model._meta.get_field(name, *args, **kwargs)
+                return meta.translations_model._meta.get_field(name, *args, **kwargs)
             except FieldDoesNotExist:
                 raise e
             else:


### PR DESCRIPTION
Whenever I add "fields" or "fieldsets" to a custom django-admin class, I get a WrongManager exception. I believe this is because of a missing return statement in `utils.py`...

The pull request is rather straight-forward and should explain itself... ;-)