### PR TITLE
Loosen admin checks so they let translated fields on most options.

### DIFF
--- a/hvad/admin.py
+++ b/hvad/admin.py
@@ -25,10 +25,12 @@ from django.template.loader import select_template
 from django.utils.encoding import iri_to_uri, force_text
 from django.utils.functional import curry
 from django.utils.translation import ugettext_lazy as _, get_language
-from hvad.compat import urlencode, urlparse
-from hvad.forms import TranslatableModelForm, translatable_inlineformset_factory, translatable_modelform_factory
-from hvad.utils import load_translation
-from hvad.manager import FALLBACK_LANGUAGES
+if django.VERSION >= (1, 7):
+    from .checks import TranslatableAdminChecks
+from .compat import urlencode, urlparse
+from .forms import TranslatableModelForm, translatable_inlineformset_factory, translatable_modelform_factory
+from .utils import load_translation
+from .manager import FALLBACK_LANGUAGES
 
 
 atomic = (transaction.atomic if django.VERSION >= (1, 6) else
@@ -109,6 +111,8 @@ class TranslatableModelAdminMixin(object):
 
 
 class TranslatableAdmin(ModelAdmin, TranslatableModelAdminMixin):
+    if django.VERSION >= (1, 7):
+        checks_class = TranslatableAdminChecks
     form = TranslatableModelForm
     
     change_form_template = 'admin/hvad/change_form.html'

--- a/hvad/checks.py
+++ b/hvad/checks.py
@@ -1,0 +1,109 @@
+from django.core import checks
+from django.db.models.fields import FieldDoesNotExist
+from django.contrib.admin.checks import ModelAdminChecks
+from .forms import TranslatableModelForm
+from .models import TranslatableModel
+
+
+class TranslatableAdminChecks(ModelAdminChecks):
+    def check(self, cls, model, **kwargs):
+        """ Include additional checks """
+        errors = []
+        errors.extend(self._check_model_translatable(cls, model))
+        errors.extend(super(TranslatableAdminChecks, self).check(cls, model, **kwargs))
+        return errors
+
+    # Custom checks
+
+    def _check_model_translatable(self, cls, model):
+        """ Make sure the translatable admin is not fed a regular model """
+        errors = []
+        if not isinstance(model, TranslatableModel):
+            errors.append(checks.Error("The model must be a subclass of TranslatableModel",
+                                       hint=None, obj=cls, id='hvad.E001'))
+        return []
+
+    # From BaseModelAdminChecks
+
+    def _check_raw_id_fields_item(self, cls, model, item, *args):
+        """ Shift the stock check for valid translated fields so it happend on translations model """
+        if _has_translated_field(model, item):
+            model = model._meta.translations_model
+        return super(TranslatableAdminChecks, self)._check_raw_id_fields_item(cls, model, item, *args)
+
+    def _check_field_spec_item(self, cls, model, item, *args):
+        if _has_translated_field(model, item):
+            return []
+        return super(TranslatableAdminChecks, self)._check_field_spec_item(cls, model, item, *args)
+
+    def _check_form(self, cls, model):
+        if hasattr(cls, 'form') and not issubclass(cls.form, TranslatableModelForm):
+            return [checks.Error("The value of 'form' must inherit from 'TranslatableModelForm'.",
+                                 hint=None, obj=cls, id='hvad.E002')]
+        return super(TranslatableAdminChecks, self)._check_form(cls, model)
+
+    def _check_prepopulated_fields_key(self, cls, model, field_name, *args):
+        """ Shift the stock check for valid translated fields so it happend on translations model """
+        if _has_translated_field(model, field_name):
+            model = model._meta.translations_model
+        return super(TranslatableAdminChecks, self)._check_prepopulated_fields_key(cls, model, field_name, *args)
+
+    def _check_prepopulated_fields_value_item(self, cls, model, field_name, *args):
+        """ Shift the stock check for valid translated fields so it happend on translations model """
+        if _has_translated_field(model, field_name):
+            model = model._meta.translations_model
+        return super(TranslatableAdminChecks, self)._check_prepopulated_fields_value_item(cls, model, field_name, *args)
+
+    def _check_ordering_item(self, cls, model, item, *args):
+        field_name = item[1:] if item.startswith('-') else item
+        if _has_translated_field(model, field_name):
+            return [refer_to_translated_field(item, 'ordering', model, cls, id='hvad.E003')]
+        return super(TranslatableAdminChecks, self)._check_ordering_item(cls, model, item, *args)
+
+    def _check_readonly_fields_item(self, cls, model, item, *args):
+        if _has_translated_field(model, item):
+            return []
+        return super(TranslatableAdminChecks, self)._check_readonly_fields_item(cls, model, item, *args)
+
+
+    # From ModelAdminChecks
+
+    def _check_list_display_item(self, cls, model, item, *args):
+        """ Bypass the stock check for valid translated fields """
+        if _has_translated_field(model, item):
+            return []
+        return super(TranslatableAdminChecks, self)._check_list_display_item(cls, model, item, *args)
+
+    def _check_list_filter_item(self, cls, model, item, *args):
+        if _has_translated_field(model, item):
+            return [refer_to_translated_field(item, 'list_filter', model, cls, id='hvad.E004')]
+        return super(TranslatableAdminChecks, self)._check_list_filter_item(cls, model, item, *args)
+
+    def _check_list_editable_item(self, cls, model, item, *args):
+        """ Replace stock check for translated fields for a more explicit message """
+        if _has_translated_field(model, item):
+            return [refer_to_translated_field(item, 'list_editable', model, cls, id='hvad.E005')]
+        return super(TranslatableAdminChecks, self)._check_list_editable_item(cls, model, item, *args)
+
+
+
+# ============================================================================
+
+def _has_translated_field(model, name):
+    try:
+        model._meta.translations_model._meta.get_field(name)
+    except FieldDoesNotExist:
+        return False
+    return True
+
+def refer_to_translated_field(field, option, model, obj, id):
+    return [
+        checks.Error(
+            "The value of '%s' refers to translated field '%s' of '%s.%s'." % (
+                option, field, model._meta.app_label, model._meta.object_name
+            ),
+            hint="Translated fields are not supported in '%s' yet." % (option,),
+            obj=obj,
+            id=id,
+        ),
+    ]

--- a/hvad/test_utils/project/app/admin.py
+++ b/hvad/test_utils/project/app/admin.py
@@ -1,5 +1,7 @@
+import django
 from django.contrib import admin
-from hvad.test_utils.project.app.models import Normal, SimpleRelated, LimitedChoice, AutoPopulated
+from hvad.test_utils.project.app.models import (Normal, SimpleRelated, AdvancedAdminModel,
+                                                LimitedChoice, AutoPopulated)
 from hvad.admin import TranslatableAdmin, TranslatableTabularInline
 
 class SimpleRelatedInline(TranslatableTabularInline):
@@ -7,6 +9,35 @@ class SimpleRelatedInline(TranslatableTabularInline):
 
 class NormalAdmin(TranslatableAdmin):
     inlines = [SimpleRelatedInline,]
+
+if django.VERSION >= (1, 7):
+    class AdvancedAdmin(TranslatableAdmin):
+        # Options for list pages
+        list_display = (
+            'shared', 'time_field',
+            'translated', 'translated_ro', 'translated_hidden',
+        )
+        list_display_links = (
+            'time_field', 'translated',
+        )
+        list_editable = ('shared',) # translated fields are not supported here
+        list_select_related = ('translated_rel',)
+        raw_id_fields = ('translated_rel',)
+
+        # list_filter - must not work on translated fields
+        # ordering - not handled on translated fields
+        # search_fields - not handled on translated fields
+
+
+        # Options for editing pages
+        fields = ('shared', 'translated', 'translated_ro')
+        exclude = ('translated_hidden',)
+        readonly_fields = ('translated_ro',)
+        prepopulated_fields = {
+            'translated': ('shared',),
+        }
+    admin.site.register(AdvancedAdminModel, AdvancedAdmin)
+
 
 admin.site.register(Normal, NormalAdmin)
 admin.site.register(SimpleRelated, TranslatableAdmin)

--- a/hvad/test_utils/project/app/models.py
+++ b/hvad/test_utils/project/app/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.template.defaultfilters import slugify
 from hvad.models import TranslatableModel, TranslatedFields
 from hvad.manager import TranslationManager, TranslationQueryset
+from hvad.utils import get_cached_translation
 from django.utils.encoding import python_2_unicode_compatible
 
 #===============================================================================
@@ -198,6 +199,36 @@ class ConcreteABProxy(ConcreteAB):
         )
     class Meta:
         proxy = True
+
+#===============================================================================
+# Models for testing admin module
+
+@python_2_unicode_compatible
+class AdvancedAdminModel(TranslatableModel):
+    shared = models.CharField(max_length=255)
+    time_field = models.DateTimeField()
+    translations = TranslatedFields(
+        translated = models.CharField(max_length=255),
+        translated_ro = models.CharField(max_length=255),
+        translated_hidden = models.CharField(max_length=255),
+        translated_rel = models.ForeignKey(Normal, related_name='+', null=True),
+    )
+
+    def __str__(self):
+        shared = '%s / %s' % (
+            self.shared, self.time_field,
+        )
+        if get_cached_translation(self) is None:
+            translated = '[none]'
+        else:
+            translated = '%s / %s / %s [%s]' % (
+                self.translated,
+                self.translated_ro,
+                self.translated_hidden,
+                self.language_code,
+            )
+        return '%s / %s' % (shared, translated)
+
 
 #===============================================================================
 # Models for testing choice limiting in foreign keys


### PR DESCRIPTION
**WIP**
Completely untested for now. Simply override relevant admin checks on Django 1.7 and newer so they do not choke on translated fields.
Tests to verify they actually work are not written yet.