### PR TITLE
Meta in modelform subclass

### DIFF
--- a/hvad/forms.py
+++ b/hvad/forms.py
@@ -34,8 +34,16 @@ class TranslatableModelFormMetaclass(ModelFormMetaclass):
     def __new__(cls, name, bases, attrs):
         # Force presence of meta class, we need it
         meta = attrs.get('Meta')
+        # If no Meta was declared directly in this class, then look
+        # for the first base class that has one.
         if meta is None:
-            meta = attrs['Meta'] = type('Meta', (object,), {})
+            for base in bases:
+                meta = getattr(base, 'Meta', None)
+                if meta:
+                    break
+        if meta is None:
+            meta = type('Meta', (object,), {})
+        attrs['Meta'] = meta
 
         model = getattr(meta, 'model', None)
         fields = getattr(meta, 'fields', None)

--- a/hvad/tests/forms.py
+++ b/hvad/tests/forms.py
@@ -63,6 +63,18 @@ class FormDeclarationTests(HvadTestCase):
         self.assertCountEqual(engineered._meta.exclude, ['translations'])
         self.assertCountEqual(engineered.base_fields, ['shared_field', 'translated_field'])
 
+    def test_no_meta_in_subclass(self):
+        'Subclass should inherit Meta'
+        class ParentForm(TranslatableModelForm):
+            class Meta:
+                model = Normal
+
+        class ChildForm(ParentForm):
+            pass
+
+        self.assertIs(ParentForm._meta.model, Normal)
+        self.assertIs(ChildForm._meta.model, Normal)
+
     def test_only_model(self):
         'Standalone form with model in Meta'
         class Form(TranslatableModelForm):


### PR DESCRIPTION
With Django's ModelForms, if you inherit from a parent class but don't declare a `Meta`, then you get the one from the parent class.

From https://docs.djangoproject.com/en/1.8/topics/forms/modelforms/#form-inheritance
> Normal Python name resolution rules apply. If you have multiple base classes that declare a Meta inner class, only the first one will be used. This means the child’s Meta, if it exists, otherwise the Meta of the first parent, etc.

I think that the way `__new__` was implemented in `TranslatableModelFormMetaclass` was altering this pattern.

I think that my fix emulates Django's way. I tried to copy the way the Django does its ModelForms, but it does it by creating the new class at the start of `__new__`, then modifying it, which I couldn't make fit here.