### PR TITLE
Convert readonly_fields to tuple before concatenating

### DIFF
--- a/hvad/admin.py
+++ b/hvad/admin.py
@@ -146,7 +146,7 @@ class TranslatableAdmin(ModelAdmin, TranslatableModelAdminMixin):
         exclude = (
             tuple(self.exclude or ()) +
             tuple(kwargs.pop("exclude", ())) +
-            self.get_readonly_fields(request, obj)
+            tuple(self.get_readonly_fields(request, obj) or ())
         )
         old_formfield_callback = curry(self.formfield_for_dbfield, request=request)
         defaults = {


### PR DESCRIPTION
A `TypeError ` exception rises when the `readonly_fields` is set as a list in the child models. 
To avoid it, convert the `list `to `tuple `before concatenating it with other tuples.