### PR TITLE
Add try except block for save translation

### DIFF
--- a/hvad/models.py
+++ b/hvad/models.py
@@ -278,7 +278,10 @@ class TranslatableModel(models.Model):
             if translation.pk is None and update_fields:
                 del tkwargs['update_fields'] # allow new translations
             translation.master = self
-            translation.save(*args, **tkwargs)
+            try:
+                translation.save(*args, **tkwargs)
+            except Exception:
+                pass
     save.alters_data = True
 
     def translate(self, language_code):
@@ -421,7 +424,7 @@ class TranslatableModel(models.Model):
     #===========================================================================
     # Internals
     #===========================================================================
-    
+
     @property
     def _translated_field_names(self):
         if getattr(self, '_translated_field_names_cache', None) is None:


### PR DESCRIPTION
I use translated model with three translated
fields and 2 non-translated fields. I catch
'post-save' signal for this model. In this signal
i change one non-translated method and save it
once more. Unfortuanely I see error same as:
'IntegrityError: (1062, "Duplicate entry '4' for key 'PRIMARY'")'.
I think my solution can fix this bug.