### PR TITLE
Force UTF-8 when reading README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import hvad
 
-with open('README.rst', 'r') as fd:
+with open('README.rst', 'r', encoding='utf-8') as fd:
     long_description = fd.read()
 
 setup(


### PR DESCRIPTION
This fixes installing from source on Windows