### PR TITLE
docs: Fix simple typo, overriden -> overridden

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ some language-aware queries::
     Book.objects.all()
 
 Compatible by default: returns all objects, without any translated fields attached.
-Starting from v1.0, default behavior can be overriden to work like next query::
+Starting from v1.0, default behavior can be overridden to work like next query::
 
     Book.objects.language().all()
 

--- a/docs/public/forms.rst
+++ b/docs/public/forms.rst
@@ -56,7 +56,7 @@ way the form chooses a language for displaying and committing.
   When in **enforce** mode, the form will always use its language, disregarding
   current language and reloading the ``instance`` it is given if it has another
   language loaded.
-* The language can be overriden manually by providing a
+* The language can be overridden manually by providing a
   :meth:`custom clean() method <django.forms.Form.clean>`.
 
 In all cases, the language is not part of the form seen by the browser or sent

--- a/docs/public/models.rst
+++ b/docs/public/models.rst
@@ -46,7 +46,7 @@ A full example of a model with translations::
           translatable fields in :attr:`~django.db.models.Options.order_with_respect_to`.
 .. note:: TranslatedFields cannot contain a field named ``master``, as this name
           is reserved by hvad to refer to the :term:`Shared Model`. Also, special
-          field ``language_code`` can be overriden in order to set it to be a
+          field ``language_code`` can be overridden in order to set it to be a
           different type of field, or change its options.
 
 ***********************
@@ -237,7 +237,7 @@ Custom Querysets
 Once you have a custom queryset, you can use it to override the default ones
 in your manager. This is where it is more complex than a regular manager:
 :class:`~hvad.manager.TranslationManager` uses three types of queryset, that
-can be overriden independently:
+can be overridden independently:
 
 - :attr:`~hvad.manager.TranslationManager.queryset_class` must inherit
   :class:`~hvad.manager.TranslationQueryset`, and will be used for all queries

--- a/docs/public/restframework.rst
+++ b/docs/public/restframework.rst
@@ -64,7 +64,7 @@ a language is chosen for serializing and deserializing.
   When in **enforce** mode, the serializer will always use its own language, disregarding
   current language and reloading the ``instance`` it is given if it has another
   language loaded.
-* The language can be overriden manually by providing a custom ``validate()``
+* The language can be overridden manually by providing a custom ``validate()``
   method. This method should set the desired language in ``data['language_code']``.
   Please refer to REST framework
   `documentation <http://www.django-rest-framework.org/api-guide/serializers/#validation>`_

--- a/hvad/forms.py
+++ b/hvad/forms.py
@@ -143,8 +143,8 @@ class BaseTranslatableModelForm(BaseModelForm):
     def _post_clean(self):
         ''' Switch the translation on self.instance
             This cannot (and should not) be done in clean() because it could be
-            overriden to change the language. Yet it should be done before save()
-            to allow an overriden save to set some translated field values before
+            overridden to change the language. Yet it should be done before save()
+            to allow an overridden save to set some translated field values before
             invoking super().
         '''
         enforce = 'language_code' in self.cleaned_data

--- a/hvad/models.py
+++ b/hvad/models.py
@@ -439,7 +439,7 @@ def prepare_translatable_model(sender, **kwargs):
     #### Now we have to work ####
 
     # Ensure _base_manager cannot be TranslationManager despite use_for_related_fields
-    # 1- it is useless unless default_class is overriden
+    # 1- it is useless unless default_class is overridden
     # 2- in that case, _base_manager is used for saving objects and must not be
     #    translation aware.
     base_mgr = getattr(model, '_base_manager', None)


### PR DESCRIPTION
There is a small typo in README.rst, docs/public/forms.rst, docs/public/models.rst, docs/public/restframework.rst, hvad/forms.py, hvad/models.py.

Should read `overridden` rather than `overriden`.

